### PR TITLE
Speedup Inference (to get Embeddings for training & new repo on-boarding) by 10x

### DIFF
--- a/Issue-Embeddings/notebooks/04b_Inference-Batch.ipynb
+++ b/Issue-Embeddings/notebooks/04b_Inference-Batch.ipynb
@@ -4,6 +4,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Background\n",
+    "\n",
+    "This notebook illustrates the use of a utility, `InferenceWrapper.df_to_emb` that can be used to perform inference in bulk on large amounts of data.  A benchmark is provided that compares doing inference one at a time in a serial fashion and demonstrates a **10x speedup in inference time** over the previous method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Location of Model Artifacts\n",
     "\n",
     "### Google Cloud Storage\n",
@@ -32,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,11 +49,16 @@
     "from IPython.display import display, Markdown\n",
     "import pandas as pd\n",
     "from torch.nn.utils.rnn import pad_sequence\n",
-    "from torch import Tensor, cat\n",
+    "from torch import Tensor, cat, device\n",
     "from torch.cuda import empty_cache\n",
     "from typing import List\n",
     "from tqdm import tqdm\n",
-    "from numpy import concatenate as cat"
+    "from numpy import concatenate as cat\n",
+    "import torch\n",
+    "import numpy as np\n",
+    "\n",
+    "# from fastai.torch_core import defaults\n",
+    "# defaults.device = torch.device('cpu')\n"
    ]
   },
   {
@@ -75,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -161,13 +175,13 @@
        "2  ## User story xxxlnbrk - En tant que :  **gest...          480  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "testdf = pd.read_csv(f'https://storage.googleapis.com/issue_label_bot/language_model_data/000000000000.csv.gz').head(2000)\n",
+    "testdf = pd.read_csv(f'https://storage.googleapis.com/issue_label_bot/language_model_data/000000000000.csv.gz').head(8000)\n",
     "\n",
     "testdf.head(3)\n",
     "\n"
@@ -193,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -202,7 +216,7 @@
      "text": [
       "Help on method df_to_emb in module inference:\n",
       "\n",
-      "df_to_emb(dataframe:pandas.core.frame.DataFrame, bs=150) -> numpy.ndarray method of inference.InferenceWrapper instance\n",
+      "df_to_emb(dataframe:pandas.core.frame.DataFrame, bs=100) -> numpy.ndarray method of inference.InferenceWrapper instance\n",
       "    Retrieve document embeddings for a dataframe with the columns `title` and `body`.\n",
       "    Uses batching for effiecient computation, which is useful when you have many documents\n",
       "    to retrieve embeddings for. \n",
@@ -242,19 +256,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Benchmarking inference time on 8,000 Issues\n",
+    "\n",
+    "#### Below is when inference is done using batching (New Method)"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "51b5c4742a4546548bbc93f4e91d4bca",
+       "model_id": "5a0c7ab3002c4620ab32d9f849073aea",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(IntProgress(value=0, description='Tokenizing and parsing text:', max=2000, style=ProgressStyle(…"
+       "HBox(children=(IntProgress(value=1, bar_style='info', description='Model inference:', max=1, style=ProgressSty…"
       ]
      },
      "metadata": {},
@@ -264,53 +287,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2922519062b04827bce52d822aa6654b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(IntProgress(value=0, description='Numericalizing text:', max=2000, style=ProgressStyle(descript…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ad9661368c004846871f9c10bb5516d6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(IntProgress(value=0, description='Model inference:', max=14, style=ProgressStyle(description_wi…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "\n",
+      "CPU times: user 1min 6s, sys: 21.5 s, total: 1min 27s\n",
+      "Wall time: 1min 28s\n"
      ]
     }
    ],
    "source": [
+    "%%time\n",
     "embeddings = wrapper.df_to_emb(testdf)"
    ]
   },
@@ -318,36 +302,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Benchmarking batch vs. one at a time\n",
-    "\n",
-    "Benchmark time to perform inference.  There is over a 2x speedup.  "
+    "#### Below is when inference is done one at a time (Old Method)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
+   "execution_count": 15,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 2000/2000 [03:45<00:00,  5.78it/s]"
+      "100%|██████████| 8000/8000 [14:48<00:00,  9.92it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3min 13s, sys: 44 s, total: 3min 57s\n",
-      "Wall time: 3min 56s\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
+      "CPU times: user 12min 42s, sys: 2min 54s, total: 15min 37s\n",
+      "Wall time: 15min 34s\n"
      ]
     }
    ],
@@ -367,12 +344,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Conclusion:\n",
+    "# Notes:\n",
     "\n",
-    "Naively batching examples doesn't really speed things up much, because any speedup you get from batching is mitigated by the extra slowdown you get from padding.  In order to get a speed improvement we must utilize [pack_padded_sequence](https://pytorch.org/docs/stable/nn.html#torch.nn.utils.rnn.pack_padded_sequence).  Which requires sorting the data by sequence length in descending order.  This also requires sorting the corresponding labels.\n",
+    "There is a **10x speedup** for inference by chunking the data into batches of similar length (to minimize padding) and passing that through the GPU.\n",
     "\n",
-    "We leave this a future exercise to optimize batching more.  In the meantime, feel free to reach eitehr batching method.\n",
-    "\n"
+    "In order to get a further speed improvement we must utilize [pad_packed_sequence](https://pytorch.org/docs/stable/nn.html#torch.nn.utils.rnn.pad_packed_sequence).  We leave this a future exercise to optimize batching more."
    ]
   },
   {
@@ -386,22 +362,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "np.allclose(emb_single_combined, embeddings, atol=1e-6)"
+    "assert np.allclose(emb_single_combined, embeddings, atol=1e-5)"
    ]
   }
  ],


### PR DESCRIPTION
### Created utility that speeds up generating of embeddings for GitHub issues by 10x when doing it in batch.

This will allow us to onboard new repos in a much more realistic timeframe and will be a much better user experience, especially for massive orgs like Kubernetes.

This was done by taking the following steps:

- Hacking the machinery of fastai datablock api to perform multi-threaded transformation for inference (there isn't an easy way out of the box to do this)
- Sorting Issues by their sequence lengths before generating batches to minimize the amount of padding necessary in each batch.
- Batching the issues together (previously we were performing inference on one issue at a time). 

![image](https://user-images.githubusercontent.com/1483922/62344210-fe424100-b4a1-11e9-9fec-b72bda520062.png)



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/code-intelligence/30)
<!-- Reviewable:end -->
