### PR TITLE
Add worker class to address events in pubsub

### DIFF
--- a/Label_Microservice/notebooks/repo_mlp.ipynb
+++ b/Label_Microservice/notebooks/repo_mlp.ipynb
@@ -142,9 +142,18 @@
     "    def save_model(self):\n",
     "        self.mlp_wrapper.save_model(model_file=self.model_file)\n",
     "        # dump label columns for prediction\n",
-    "        label_dict = {'labels': self.all_labels, 'probability_thresholds': self.probability_thresholds}\n",
-    "        with open(self.labels_file, 'wb') as f:\n",
-    "            dpickle.dump(label_dict, f)\n",
+    "        thresholds = {}\n",
+    "        for i in self.probability_thresholds:\n",
+    "            if self.probability_thresholds[i]:\n",
+    "                thresholds[i] = float(self.probability_thresholds[i])\n",
+    "            else:\n",
+    "                thresholds[i] = None\n",
+    "        label_dict = {\n",
+    "            'labels': self.all_labels,\n",
+    "            'probability_thresholds': thresholds\n",
+    "        }\n",
+    "        with open(self.labels_file, 'w') as f:\n",
+    "            yaml.dump(label_dict, f)\n",
     "\n",
     "        self.upload_model_to_gcs()\n",
     "\n",
@@ -175,7 +184,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "r = RepoMLP()"
+    "r = RepoMLP(owner='kubeflow', repo='examples')"
    ]
   },
   {

--- a/Label_Microservice/requirements.txt
+++ b/Label_Microservice/requirements.txt
@@ -33,15 +33,19 @@ fastai==1.0.55
 fastprogress==0.1.21
 fire==0.1.3
 future==0.17.1
+github3.py==1.3.0
 google-api-core==1.14.2
 google-api-python-client==1.7.10
 google-auth==1.6.3
 google-auth-httplib2==0.0.3
 google-cloud-bigquery==1.17.0
 google-cloud-core==1.0.3
+google-cloud-pubsub==0.45.0
 google-cloud-storage==1.17.0
 google-resumable-media==0.3.2
 googleapis-common-protos==1.6.0
+grpc-google-iam-v1==0.12.3
+grpcio==1.22.0
 html5lib==1.0.1
 httplib2==0.13.1
 idna==2.8
@@ -60,6 +64,7 @@ jupyter==1.0.0
 jupyter-client==5.3.1
 jupyter-console==6.0.0
 jupyter-core==4.5.0
+jwcrypto==0.6.0
 kfp==0.1.25
 kfp-server-api==0.1.18.3
 kiwisolver==1.1.0

--- a/Label_Microservice/tests/test_mlp.py
+++ b/Label_Microservice/tests/test_mlp.py
@@ -4,7 +4,7 @@ import numpy as np
 from sklearn.neural_network import MLPClassifier
 from sklearn.model_selection import train_test_split
 
-def test_predict_proba():
+def test_predict_probabilities():
     n_classes = 5
     n_samples = 20
     embedding_size = 5
@@ -19,7 +19,7 @@ def test_predict_proba():
 
     mlp_wrap = MLPWrapper(clf=mlp_clf)
     mlp_wrap.fit(X_train, y_train)
-    mlp_wrap_pred = mlp_wrap.predict_proba(X_test)
+    mlp_wrap_pred = mlp_wrap.predict_probabilities(X_test)
     assert mlp_clf_pred.all() == mlp_wrap_pred.all()
 
 

--- a/Label_Microservice/tests/test_worker.py
+++ b/Label_Microservice/tests/test_worker.py
@@ -1,0 +1,93 @@
+import unittest
+from unittest.mock import Mock
+import os
+import label_microservice
+from label_microservice.worker import Worker
+import code_intelligence
+
+class TestWorker(unittest.TestCase):
+
+    def test_get_issue_embedding(self):
+        """Testing get_issue_embedding function while status code is not 200"""
+        label_microservice.worker.github_init = Mock()
+        Worker.create_subscription_if_not_exists = Mock()
+
+        label_microservice.worker.get_issue_text = Mock()
+        label_microservice.worker.get_issue_text.return_value = {
+                'title': 'test_title',
+                'body': 'test_body'
+            }
+        label_microservice.worker.requests.post = Mock()
+        label_microservice.worker.requests.post.return_value.status_code = 404
+        issue_embedding = Worker().get_issue_embedding('repo_owner', 'repo_name', 'issue_num')
+        assert not issue_embedding
+
+    def teat_predict_issue_probability_not_retrieve_embedding(self):
+        """Testing predict_issue_probability function while not retrieving embedding"""
+        label_microservice.worker.github_init = Mock()
+        Worker.create_subscription_if_not_exists = Mock()
+
+        Worker.get_issue_embedding = Mock()
+        Worker.get_issue_embedding.return_value = None
+        label_probabilities, issue_embedding = Worker().predict_issue_probability('repo_owner', 'repo_name', 'issue_num')
+        assert label_probabilities == [] and not issue_embedding
+
+    def test_predict_labels(self):
+        """Testing predict_labels function"""
+        label_microservice.worker.github_init = Mock()
+        Worker.create_subscription_if_not_exists = Mock()
+
+        Worker.predict_issue_probability = Mock()
+        Worker.predict_issue_probability.return_value = ([0.7, 0.6, 0.5], None)
+        Worker.load_label_columns = Mock()
+        Worker.load_label_columns.return_value = {
+                'labels': ['label1', 'label2', 'label3'],
+                'probability_thresholds': {0: 0.6, 1: 0.7, 2: 0.5}
+            }
+        predictions, _ = Worker().predict_labels('repo_owner', 'repo_name', 'issue_num')
+        assert predictions['labels'] == ['label1', 'label3'] and\
+            predictions['probabilities'] == [0.7, 0.5]
+
+    def test_predict_labels_not_retrieve_embedding(self):
+        """Testing predict_labels function"""
+        label_microservice.worker.github_init = Mock()
+        Worker.create_subscription_if_not_exists = Mock()
+
+        Worker.predict_issue_probability = Mock()
+        Worker.predict_issue_probability.return_value = ([0.7, 0.6, 0.5], None)
+        Worker.load_label_columns = Mock()
+        Worker.load_label_columns.return_value = {
+                'labels': ['label1', 'label2', 'label3'],
+                'probability_thresholds': {0: 0.6, 1: 0.7, 2: 0.5}
+            }
+        predictions, _ = Worker().predict_labels('repo_owner', 'repo_name', 'issue_num')
+        assert predictions['labels'] == ['label1', 'label3'] and\
+            predictions['probabilities'] == [0.7, 0.5]
+
+    def test_filter_specified_labels(self):
+        """Testing filter_specified_labels function when yaml specifies labels"""
+        # init setting
+        os.environ['GH_ISSUE_API_KEY'] = ''
+        os.environ['APP_URL'] = ''
+        label_microservice.worker.github_init = Mock()
+        Worker.create_subscription_if_not_exists = Mock()
+
+        label_microservice.worker.get_yaml = Mock()
+        label_microservice.worker.get_yaml.return_value = {'predicted-labels': {'label1': None, 'label2': None}}
+        predictions = {'labels': ['label1', 'label3'], 'probabilities': [0.7, 0.8]}
+        label_names, label_probabilities = Worker().filter_specified_labels('repo_owner', 'repo_name', predictions)
+        assert label_names == ['label1'] and label_probabilities == [0.7]
+
+    def test_filter_specified_labels_yaml_not_specified(self):
+        """Testing filter_specified_labels function when yaml not specifies labels"""
+        # init setting
+        os.environ['GH_ISSUE_API_KEY'] = ''
+        os.environ['APP_URL'] = ''
+        label_microservice.worker.github_init = Mock()
+        Worker.create_subscription_if_not_exists = Mock()
+
+        label_microservice.worker.get_yaml = Mock()
+        label_microservice.worker.get_yaml.return_value = None
+        predictions = {'labels': ['label1', 'label3'], 'probabilities': [0.7, 0.8]}
+        label_names, label_probabilities = Worker().filter_specified_labels('repo_owner', 'repo_name', predictions)
+        assert label_names == predictions['labels'] and label_probabilities == predictions['probabilities']

--- a/Label_Microservice/tests/test_worker.py
+++ b/Label_Microservice/tests/test_worker.py
@@ -9,6 +9,9 @@ class TestWorker(unittest.TestCase):
 
     def test_get_issue_embedding(self):
         """Testing get_issue_embedding function while status code is not 200"""
+        # init setting
+        os.environ['GH_ISSUE_API_KEY'] = ''
+        os.environ['APP_URL'] = ''
         label_microservice.worker.github_init = Mock()
         Worker.create_subscription_if_not_exists = Mock()
 
@@ -17,23 +20,33 @@ class TestWorker(unittest.TestCase):
                 'title': 'test_title',
                 'body': 'test_body'
             }
+        # let status code to be 404
         label_microservice.worker.requests.post = Mock()
         label_microservice.worker.requests.post.return_value.status_code = 404
         issue_embedding = Worker().get_issue_embedding('repo_owner', 'repo_name', 'issue_num')
+        # issue_embedding should be None
         assert not issue_embedding
 
     def teat_predict_issue_probability_not_retrieve_embedding(self):
         """Testing predict_issue_probability function while not retrieving embedding"""
+        # init setting
+        os.environ['GH_ISSUE_API_KEY'] = ''
+        os.environ['APP_URL'] = ''
         label_microservice.worker.github_init = Mock()
         Worker.create_subscription_if_not_exists = Mock()
 
+        # let worker to not retrive embedding of an issue
         Worker.get_issue_embedding = Mock()
         Worker.get_issue_embedding.return_value = None
         label_probabilities, issue_embedding = Worker().predict_issue_probability('repo_owner', 'repo_name', 'issue_num')
+        # issue_embedding is None, no predict probabilities
         assert label_probabilities == [] and not issue_embedding
 
     def test_predict_labels(self):
         """Testing predict_labels function"""
+        # init setting
+        os.environ['GH_ISSUE_API_KEY'] = ''
+        os.environ['APP_URL'] = ''
         label_microservice.worker.github_init = Mock()
         Worker.create_subscription_if_not_exists = Mock()
 
@@ -45,22 +58,7 @@ class TestWorker(unittest.TestCase):
                 'probability_thresholds': {0: 0.6, 1: 0.7, 2: 0.5}
             }
         predictions, _ = Worker().predict_labels('repo_owner', 'repo_name', 'issue_num')
-        assert predictions['labels'] == ['label1', 'label3'] and\
-            predictions['probabilities'] == [0.7, 0.5]
-
-    def test_predict_labels_not_retrieve_embedding(self):
-        """Testing predict_labels function"""
-        label_microservice.worker.github_init = Mock()
-        Worker.create_subscription_if_not_exists = Mock()
-
-        Worker.predict_issue_probability = Mock()
-        Worker.predict_issue_probability.return_value = ([0.7, 0.6, 0.5], None)
-        Worker.load_label_columns = Mock()
-        Worker.load_label_columns.return_value = {
-                'labels': ['label1', 'label2', 'label3'],
-                'probability_thresholds': {0: 0.6, 1: 0.7, 2: 0.5}
-            }
-        predictions, _ = Worker().predict_labels('repo_owner', 'repo_name', 'issue_num')
+        # label1 and label3 satisfy thresholds
         assert predictions['labels'] == ['label1', 'label3'] and\
             predictions['probabilities'] == [0.7, 0.5]
 
@@ -76,6 +74,7 @@ class TestWorker(unittest.TestCase):
         label_microservice.worker.get_yaml.return_value = {'predicted-labels': {'label1': None, 'label2': None}}
         predictions = {'labels': ['label1', 'label3'], 'probabilities': [0.7, 0.8]}
         label_names, label_probabilities = Worker().filter_specified_labels('repo_owner', 'repo_name', predictions)
+        # only label1 in the predicted label list
         assert label_names == ['label1'] and label_probabilities == [0.7]
 
     def test_filter_specified_labels_yaml_not_specified(self):
@@ -90,4 +89,5 @@ class TestWorker(unittest.TestCase):
         label_microservice.worker.get_yaml.return_value = None
         predictions = {'labels': ['label1', 'label3'], 'probabilities': [0.7, 0.8]}
         label_names, label_probabilities = Worker().filter_specified_labels('repo_owner', 'repo_name', predictions)
+        # not specified in the yaml, predict all satisfying thresholds
         assert label_names == predictions['labels'] and label_probabilities == predictions['probabilities']

--- a/py/code_intelligence/embeddings.py
+++ b/py/code_intelligence/embeddings.py
@@ -31,7 +31,7 @@ def find_max_issue_num(owner, repo):
     issue_num = issue_meta.strip().split('\n')[0][1:]
     return int(issue_num)
 
-def get_issue_text(num, idx, owner, repo, skip_issue=True, check_label=True):
+def get_issue_text(num, idx, owner, repo, skip_issue=True):
     """
     Get the raw text of an issue body and label.
 
@@ -61,8 +61,9 @@ def get_issue_text(num, idx, owner, repo, skip_issue=True, check_label=True):
     body = body_find.get_text().strip()
     labels = label_find.get_text().strip().split('\n')
 
-    if check_label and labels[0] == 'None yet':
-        return None
+    if labels[0] == 'None yet':
+        # return issues even though they haven't been labeled
+        labels = []
 
     return {'title':title,
             'url':url,

--- a/py/code_intelligence/embeddings.py
+++ b/py/code_intelligence/embeddings.py
@@ -31,7 +31,7 @@ def find_max_issue_num(owner, repo):
     issue_num = issue_meta.strip().split('\n')[0][1:]
     return int(issue_num)
 
-def get_issue_text(num, idx, owner, repo, skip_issue=True):
+def get_issue_text(num, idx, owner, repo, skip_issue=True, check_label=True):
     """
     Get the raw text of an issue body and label.
 
@@ -61,7 +61,7 @@ def get_issue_text(num, idx, owner, repo, skip_issue=True):
     body = body_find.get_text().strip()
     labels = label_find.get_text().strip().split('\n')
 
-    if labels[0] == 'None yet':
+    if check_label and labels[0] == 'None yet':
         return None
 
     return {'title':title,

--- a/py/code_intelligence/github_app.py
+++ b/py/code_intelligence/github_app.py
@@ -1,0 +1,183 @@
+from collections import namedtuple, Counter
+from github3 import GitHub
+from pathlib import Path
+from cryptography.hazmat.backends import default_backend
+import time
+import json
+import jwt
+import requests
+from tqdm import tqdm
+from typing import List
+
+class GitHubApp(GitHub):
+    """
+    This is a small wrapper around the github3.py library
+
+    Provides some convenience functions for testing purposes.
+    """
+
+    def __init__(self, pem_path, app_id):
+        super().__init__()
+
+        self.path = Path(pem_path)
+        self.app_id = app_id
+
+        if not self.path.is_file():
+            raise ValueError(f'argument: `pem_path` must be a valid filename. {pem_path} was not found.')
+
+    def get_app(self):
+        with open(self.path, 'rb') as key_file:
+            client = GitHub()
+            client.login_as_app(private_key_pem=key_file.read(),
+                        app_id=self.app_id)
+        return client
+
+    def get_installation(self, installation_id):
+        "login as app installation without requesting previously gathered data."
+        with open(self.path, 'rb') as key_file:
+            client = GitHub()
+            client.login_as_app_installation(private_key_pem=key_file.read(),
+                                             app_id=self.app_id,
+                                             installation_id=installation_id)
+        return client
+
+    def get_test_installation_id(self):
+        "Get a sample test_installation id."
+        client = self.get_app()
+        return next(client.app_installations()).id
+
+    def get_test_installation(self):
+        "login as app installation with the first installation_id retrieved."
+        return self.get_installation(self.get_test_installation_id())
+
+    def get_test_repo(self):
+        repo = self.get_all_repos(self.get_test_installation_id())[0]
+        appInstallation = self.get_test_installation()
+        owner, name = repo['full_name'].split('/')
+        return appInstallation.repository(owner, name)
+
+    def get_test_issue(self):
+        test_repo = self.get_test_repo()
+        return next(test_repo.issues())
+
+    def get_jwt(self):
+        """
+        This is needed to retrieve the installation access token (for debugging).
+
+        Useful for debugging purposes.  Must call .decode() on returned object to get string.
+        """
+        now = self._now_int()
+        payload = {
+            "iat": now,
+            "exp": now + (60),
+            "iss": self.app_id
+        }
+        with open(self.path, 'rb') as key_file:
+            private_key = default_backend().load_pem_private_key(key_file.read(), None)
+            return jwt.encode(payload, private_key, algorithm='RS256')
+
+    def get_installation_id(self, owner, repo):
+        "https://developer.github.com/v3/apps/#find-repository-installation"
+        url = f'https://api.github.com/repos/{owner}/{repo}/installation'
+
+        headers = {'Authorization': f'Bearer {self.get_jwt().decode()}',
+                   'Accept': 'application/vnd.github.machine-man-preview+json'}
+
+        response = requests.get(url=url, headers=headers)
+        if response.status_code != 200:
+            raise Exception(f'Status code : {response.status_code}, {response.json()}')
+        return response.json()['id']
+
+    def get_installation_access_token(self, installation_id):
+        "Get the installation access token for debugging."
+
+        url = f'https://api.github.com/app/installations/{installation_id}/access_tokens'
+        headers = {'Authorization': f'Bearer {self.get_jwt().decode()}',
+                   'Accept': 'application/vnd.github.machine-man-preview+json'}
+
+        response = requests.post(url=url, headers=headers)
+        if response.status_code != 201:
+            raise Exception(f'Status code : {response.status_code}, {response.json()}')
+        return response.json()['token']
+
+    def _extract(self, d, keys):
+        "extract selected keys from a dict."
+        return dict((k, d[k]) for k in keys if k in d)
+
+    def _now_int(self):
+        return int(time.time())
+
+    def get_all_repos(self, installation_id):
+        """Get all repos that this installation has access to.
+
+        Useful for testing and debugging.
+        """
+        url = 'https://api.github.com/installation/repositories'
+        headers={'Authorization': f'token {self.get_installation_access_token(installation_id)}',
+                 'Accept': 'application/vnd.github.machine-man-preview+json'}
+
+        response = requests.get(url=url, headers=headers)
+
+        if response.status_code >= 400:
+            raise Exception(f'Status code : {response.status_code}, {response.json()}')
+
+        fields = ['name', 'full_name', 'id']
+        return [self._extract(x, fields) for x in response.json()['repositories']]
+
+    def get_reactions(self, owner: str, repo: str, comment_id: int, iat: str):
+        """Get a list of reactions.
+
+        https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment
+        """
+        url = f'https://api.github.com/repos/{owner}/{repo}/issues/comments/{comment_id}/reactions'
+        # installation_id = self.get_installation_id(owner, repo)
+        # headers={'Authorization': f'token {self.get_installation_access_token(installation_id)}',
+        #          'Accept': 'application/vnd.github.squirrel-girl-preview+json'}
+        headers={'Authorization': f'token {iat}',
+                 'Accept': 'application/vnd.github.squirrel-girl-preview+json'}
+
+        response = requests.get(url=url, headers=headers)
+
+        if response.status_code >= 400:
+            raise Exception(f'Status code : {response.status_code}, {response.json()}')
+
+        results = [self._extract(x, ['content']) for x in response.json()]
+        # count the reactions
+        return Counter([x['content'] for x in results])
+
+
+    @staticmethod
+    def unpack_issues(client, owner, repo, label_only=True):
+        """
+        extract relevant data from issues.
+
+        returns a list of namedtuples which contains the following fields:
+            title: str
+            number: int
+            body: str
+            labels: list
+            url: str
+
+        """
+        Issue = namedtuple('Issue', ['title', 'number', 'body', 'labels', 'url'])
+
+        issue_data = []
+        issues = list(client.issues_on(owner, repo))
+        for issue in tqdm(issues, total=len(issues)):
+            labels=[label.name for label in issue.labels()]
+
+            # if there are no labels, then optionally skip
+            if label_only and not labels:
+                continue
+
+            issue_data.append(Issue(title=issue.title,
+                                    number=issue.number,
+                                    body=issue.body,
+                                    labels=[label.name for label in issue.labels()],
+                                    url=issue.html_url)
+                             )
+        return issue_data
+
+    def generate_installation_curl(self, endpoint):
+        iat = self.get_installation_access_token()
+        print(f'curl -i -H "Authorization: token {iat}" -H "Accept: application/vnd.github.machine-man-preview+json" https://api.github.com{endpoint}')

--- a/py/code_intelligence/github_util.py
+++ b/py/code_intelligence/github_util.py
@@ -1,0 +1,47 @@
+import os
+import logging
+from code_intelligence.github_app import GitHubApp
+import yaml
+
+
+def init():
+    "Load all necessary artifacts to make predictions."
+    #save keyfile
+    pem_string = os.getenv('PRIVATE_KEY')
+    if not pem_string:
+        raise ValueError('Environment variable PRIVATE_KEY was not supplied.')
+
+    with open('private-key.pem', 'wb') as f:
+        f.write(str.encode(pem_string))
+
+def get_app():
+    "grab a fresh instance of the app handle."
+    app_id = os.getenv('APP_ID')
+    key_file_path = 'private-key.pem'
+    ghapp = GitHubApp(pem_path=key_file_path, app_id=app_id)
+    return ghapp
+
+def get_issue_handle(installation_id, username, repository, number):
+    "get an issue object."
+    ghapp = get_app()
+    install = ghapp.get_installation(installation_id)
+    return install.issue(username, repository, number)
+
+def get_yaml(owner, repo):
+    """
+    Looks for the yaml file in a /.github directory.
+
+    yaml file must be named issue_label_bot.yaml
+    """
+    ghapp = get_app()
+    try:
+        # get the app installation handle
+        inst_id = ghapp.get_installation_id(owner=owner, repo=repo)
+        inst = ghapp.get_installation(installation_id=inst_id)
+        # get the repo handle, which allows you got get the file contents
+        repo = inst.repository(owner=owner, repository=repo)
+        results = repo.file_contents('.github/issue_label_bot.yaml').decoded
+    except:
+        return None
+
+    return yaml.safe_load(results)

--- a/py/label_microservice/mlp.py
+++ b/py/label_microservice/mlp.py
@@ -2,6 +2,7 @@ from sklearn.neural_network import MLPClassifier
 from sklearn.model_selection import GridSearchCV
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import precision_recall_curve
+import os
 import dill as dpickle
 import numpy as np
 import pandas as pd
@@ -14,16 +15,20 @@ class MLPWrapper:
                  clf,
                  model_file="model.dpkl",
                  precision_threshold=0.7,
-                 recall_threshold=0.5):
+                 recall_threshold=0.5,
+                 load_from_model=False):
         """Initialize parameters of the MLP classifier
         Args:
           clf: a sklearn.neural_network.MLPClassifier object
           model_file: the local path to save or load model
           precision_threshold: the threshold that the precision of one label must meet in order to be predicted
           recall_threshold: the threshold that the recall of one label must meet in order to be predicted
+          load_from_model: load classifier from model file or not
         """
         if clf:
             self.clf = clf
+        elif load_from_model:
+            self.load_model(model_file=model_file)
         else:
             raise Exception("You need to pass a MLPClassifier object to the wrapper")
         self.model_file = model_file
@@ -125,5 +130,7 @@ class MLPWrapper:
         """
         if model_file:
             self.model_file = model_file
+        if not os.path.exists(self.model_file):
+            raise Exception("Model path {self.model_file} does not exist")
         with open(self.model_file, 'rb') as f:
             self.clf = dpickle.load(f)

--- a/py/label_microservice/mlp.py
+++ b/py/label_microservice/mlp.py
@@ -51,7 +51,7 @@ class MLPWrapper:
         """
         self.clf.fit(X, y)
 
-    def predict_proba(self, X):
+    def predict_probabilities(self, X):
         """Predict probabilities of all labels for data
         Args:
           X: features, numpy.array
@@ -69,7 +69,7 @@ class MLPWrapper:
         # split data
         X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=test_size, random_state=1234)
         self.fit(X_train, y_train)
-        y_pred = self.predict_proba(X_test)
+        y_pred = self.predict_probabilities(X_test)
 
         self.probability_thresholds = {}
         self.precisions = {}

--- a/py/label_microservice/repo_config.py
+++ b/py/label_microservice/repo_config.py
@@ -33,12 +33,12 @@ class RepoConfig:
         self.model_bucket_name = 'repo-models'
         self.embeddings_bucket_name = 'repo-embeddings'
 
-        self.model_gcs_path = f'{self.repo_owner}/{self.repo_name}.model'
-        self.labels_gcs_path = f'{self.repo_owner}/{self.repo_name}.labels'
-        self.embeddings_gcs_path = f'{self.repo_owner}/{self.repo_name}'
+        self.model_gcs_path = f'{self.repo_owner}/{self.repo_name}.model.dpkl'
+        self.labels_gcs_path = f'{self.repo_owner}/{self.repo_name}.labels.yaml'
+        self.embeddings_gcs_path = f'{self.repo_owner}/{self.repo_name}.dpkl'
 
         self.model_local_path = f'{self.repo_name}.dpkl'
-        self.labels_local_path = f'{self.repo_name}.labels.dpkl'
+        self.labels_local_path = f'{self.repo_name}.labels.yaml'
         self.embeddings_local_path = f'{self.repo_name}.emb.dpkl'
 
     def download_yaml_from_gcs(self, repo_owner, repo_name):

--- a/py/label_microservice/worker.py
+++ b/py/label_microservice/worker.py
@@ -199,7 +199,6 @@ class Worker:
         issue_text = get_issue_text(owner=repo_owner,
                                     repo=repo_name,
                                     num=issue_num,
-                                    check_label=False,
                                     idx=None)
         data = {'title': issue_text['title'],
                 'body': issue_text['body']}

--- a/py/label_microservice/worker.py
+++ b/py/label_microservice/worker.py
@@ -1,0 +1,351 @@
+import os
+import fire
+import dill as dpickle
+import requests
+import json
+import numpy as np
+from bs4 import BeautifulSoup
+from passlib.apps import custom_app_context as pwd_context
+from google.cloud import pubsub
+from google.cloud import storage
+import logging
+from label_microservice.repo_config import RepoConfig
+from label_microservice.mlp import MLPWrapper
+from code_intelligence.github_util import init as github_init
+from code_intelligence.github_util import get_issue_handle
+from code_intelligence.github_util import get_yaml
+from code_intelligence.embeddings import get_issue_text
+
+class Worker:
+    """
+    The worker class aims to do label prediction for issues from github repos.
+    The processes are the following:
+    Listen to events in Google Cloud PubSub.
+    Load the model mapped to the current event.
+    Generate label prediction and check thresholds.
+    Call GitHub API to add labels if needed.
+    """
+
+    def __init__(self,
+                 project_id='issue-label-bot-dev',
+                 topic_name='event_queue',
+                 subscription_name='subscription_for_event_queue',
+                 embedding_api_endpoint='https://embeddings.gh-issue-labeler.com/text'):
+        """
+        Initialize the parameters and GitHub app.
+        Args:
+          project_id: gcp project id, str
+          topic_name: pubsub topic name, str
+          subscription_name: pubsub subscription name, str
+          embedding_api_endpoint: endpoint of embedding api microservice, str
+        """
+        # TODO(chunhsiang): change the embedding microservice to be an internal DNS of k8s service.
+        #   see: https://v1-12.docs.kubernetes.io/docs/concepts/services-networking/dns-pod-service/#services
+        self.project_id = project_id
+        self.topic_name = topic_name
+        self.subscription_name = subscription_name
+        self.embedding_api_endpoint = embedding_api_endpoint
+        self.embedding_api_key = os.environ['GH_ISSUE_API_KEY']
+        self.app_url = os.environ['APP_URL']
+
+        # init GitHub app
+        github_init()
+        # init pubsub subscription
+        self.create_subscription_if_not_exists()
+
+    def load_yaml(self, repo_owner, repo_name):
+        """
+        Load config from the YAML of the specific repo_owner/repo_name.
+        Args:
+          repo_owner: str
+          repo_name: str
+        """
+        # TODO(chunhsiang): for now all the paths including gcs and local sides
+        #   are set using repo_owner/repo_name (see repo_config.py), meaning the
+        #   paths returned from `RepoConfig(...)` are related to the specific
+        #   repo_owner/repo_name.
+        #   Will update them after finish the config map.
+        config = RepoConfig(repo_owner=repo_owner, repo_name=repo_name)
+        self.repo_owner = config.repo_owner
+        self.repo_name = config.repo_name
+
+        self.model_bucket_name = config.model_bucket_name
+        self.model_file = config.model_local_path
+        self.model_dest = config.model_gcs_path
+
+        self.labels_file = config.labels_local_path
+        self.labels_dest = config.labels_gcs_path
+
+        self.embeddings_bucket_name = config.embeddings_bucket_name
+        self.embeddings_file = config.embeddings_local_path
+        self.embeddings_dest = config.embeddings_gcs_path
+
+    def check_subscription_path_exists(self, subscription_path):
+        """
+        Check if the subscription path exists in the project.
+        Args:
+          subscription_path: subscription path in pubsub
+
+        Return
+        ------
+        bool
+            subscription_path exists in the project or not
+        """
+        subscriber = pubsub.SubscriberClient()
+        project_path = subscriber.project_path(self.project_id)
+        for existing_subscription_path in subscriber.list_subscriptions(project_path):
+            if existing_subscription_path.name == subscription_path:
+                logging.info(f'The subscription path {subscription_path} already exists')
+                return True
+        return False
+
+    def create_subscription_if_not_exists(self):
+        """
+        Create a new pull subscription on the topic if not exists.
+
+        While multiple subscribers listen to the same subscription,
+        subscribers receive a subset of the messages.
+        """
+        subscriber = pubsub.SubscriberClient()
+        publisher = pubsub.PublisherClient()
+        topic_path = publisher.topic_path(self.project_id,
+                                          self.topic_name)
+        subscription_path = subscriber.subscription_path(self.project_id,
+                                                         self.subscription_name)
+        if self.check_subscription_path_exists(subscription_path):
+            return
+        subscriber.create_subscription(name=subscription_path, topic=topic_path)
+
+    def subscribe(self):
+        """
+        Receive messages from a pull subscription.
+        When the subscriber receives a message from pubsub,
+        it will call the `callback` function to do label
+        prediction and add labels to the issue.
+        """
+        subscriber = pubsub.SubscriberClient()
+        subscription_path = subscriber.subscription_path(self.project_id,
+                                                         self.subscription_name)
+
+        def callback(message):
+            """
+            Address events in pubsub by sequential procedures.
+            Load the model mapped to the events.
+            Do label prediction.
+            Add labels if the confidence is enough.
+            Args:
+              Object:
+              message =
+                  Message {
+                      data: b'New issue.',
+                      attributes: {
+                          'installation_id': '10000',
+                          'repo_owner': 'kubeflow',
+                          'repo_name': 'examples',
+                          'issue_num': '1'
+                      }
+                  }
+            """
+            installation_id = message.attributes['installation_id']
+            repo_owner = message.attributes['repo_owner']
+            repo_name = message.attributes['repo_name']
+            issue_num = message.attributes['issue_num']
+            logging.info(f'Receive issue #{issue_num} from {repo_owner}/{repo_name}')
+
+            # predict labels
+            self.load_yaml(repo_owner, repo_name)
+            self.download_model_from_gcs()
+            predictions, issue_embedding = self.predict_labels(repo_owner, repo_name, issue_num)
+            self.add_labels_to_issue(installation_id, repo_owner, repo_name,
+                                     issue_num, predictions)
+
+            # log the prediction, which will be used to track the performance
+            log_dict = {
+                'repo_owner': repo_owner,
+                'repo_name': repo_name,
+                'issue_num': int(issue_num),
+                'labels': predictions['labels']
+            }
+            logging.info(log_dict)
+
+            # acknowledge the message, or pubsub will repeatedly attempt to deliver it
+            message.ack()
+
+        # limit the subscriber to only have one outstanding message at a time
+        flow_control = pubsub.types.FlowControl(max_messages=1)
+        future = subscriber.subscribe(subscription_path,
+                                      callback=callback,
+                                      flow_control=flow_control)
+        try:
+            logging.info(future.result())
+        except KeyboardInterrupt:
+            logging.info(future.cancel())
+
+    def get_issue_embedding(self, repo_owner, repo_name, issue_num):
+        """
+        Get the embedding of the issue by calling GitHub Issue
+        Embeddings API endpoint.
+        Args:
+          repo_owner: repo owner
+          repo_name: repo name
+          issue_num: issue index
+
+        Return
+        ------
+        numpy.ndarray
+            shape: (1600,)
+        """
+
+        issue_text = get_issue_text(owner=repo_owner,
+                                    repo=repo_name,
+                                    num=issue_num,
+                                    check_label=False,
+                                    idx=None)
+        data = {'title': issue_text['title'],
+                'body': issue_text['body']}
+
+        # sending post request and saving response as response object
+        r = requests.post(url=self.embedding_api_endpoint,
+                          headers={'Token': pwd_context.hash(self.embedding_api_key)},
+                          json=data)
+
+        embeddings = np.frombuffer(r.content, dtype='<f4')[:1600]
+        return embeddings
+
+    def download_model_from_gcs(self):
+        """Download the model from GCS to local path."""
+        # download model
+        storage_client = storage.Client()
+        bucket = storage_client.get_bucket(self.model_bucket_name)
+        blob = bucket.get_blob(self.model_dest)
+        with open(self.model_file, 'wb') as f:
+            blob.download_to_file(f)
+
+        # download lable columns
+        storage_client = storage.Client()
+        bucket = storage_client.get_bucket(self.model_bucket_name)
+        blob = bucket.get_blob(self.labels_dest)
+        with open(self.labels_file, 'wb') as f:
+            blob.download_to_file(f)
+
+    def load_label_columns(self):
+        """
+        Load label info from local path.
+
+        Return
+        ------
+        dict
+            {'labels': list, 'probability_thresholds': {label_index: threshold}}
+        """
+        with open(self.labels_file, 'rb') as f:
+            label_columns = dpickle.load(f)
+        return label_columns
+
+    def predict_labels(self, repo_owner, repo_name, issue_num):
+        """
+        Predict labels for given issue.
+        Args:
+          repo_owner: repo owner
+          repo_name: repo name
+          issue_num: issue index
+
+        Return
+        ------
+        dict
+            {'labels': list, 'probabilities': list}
+        numpy.ndarray
+            shape: (1600,)
+        """
+        logging.info(f'Predicting labels for the issue #{issue_num} from {repo_owner}/{repo_name}')
+        issue_embedding = self.get_issue_embedding(repo_owner=repo_owner,
+                                                   repo_name=repo_name,
+                                                   issue_num=issue_num)
+        mlp_wrapper = MLPWrapper(clf=None,
+                                 model_file=self.model_file,
+                                 load_from_model=True)
+        # change embedding from 1d to 2d for prediction and extract the result
+        label_probabilities = mlp_wrapper.predict_proba([issue_embedding])[0]
+
+        # get label info from local file
+        label_columns = self.load_label_columns()
+        label_names = label_columns['labels']
+        label_thresholds = label_columns['probability_thresholds']
+
+        # check thresholds to get labels that need to be predicted
+        predictions = {'labels': [], 'probabilities': []}
+        for i in range(len(label_probabilities)):
+            # if the threshold of any label is None, just ignore it
+            # because the label does not meet both of precision & recall thresholds
+            if label_thresholds[i] and label_probabilities[i] >= label_thresholds[i]:
+                predictions['labels'].append(label_names[i])
+                predictions['probabilities'].append(label_probabilities[i])
+        return predictions, issue_embedding
+
+    def add_labels_to_issue(self, installation_id, repo_owner, repo_name,
+                            issue_num, predictions):
+        """
+        Add predicted labels to issue using GitHub API.
+        Args:
+          installation_id: repo installation id
+          repo_owner: repo owner
+          repo_name: repo name
+          issue_num: issue index
+          prediction: predicted result from `predict_labels()` function
+                      dict {'labels': list, 'probabilities': list}
+        """
+        # take an action if the prediction is confident enough
+        label_names = []
+        label_probabilities = []
+        if predictions['labels']:
+            # handle the yaml file
+            yaml = get_yaml(owner=repo_owner, repo=repo_name)
+            # user may set the labels they want to predict
+            if yaml and 'predicted-labels' in yaml:
+                for name, proba in zip(predictions['labels'], predictions['probabilities']):
+                    if name in yaml['predicted-labels']:
+                        label_names.append(name)
+                        label_probabilities.append(proba)
+            else:
+                logging.warning(f'YAML file does not contain `predicted-labels`, '
+                                 'bot will predict all labels with enough confidence')
+                # if user do not set `predicted-labels`,
+                # predict all labels with enough confidence
+                label_names = predictions['labels']
+                label_probabilities = predictions['probabilities']
+
+        # get the isssue handle
+        issue = get_issue_handle(installation_id, repo_owner, repo_name, issue_num)
+
+        if label_names:
+            # create message
+            message = """Issue-Label Bot is automatically applying the labels `{labels}` to this issue, with the confidence of {confidence}.
+            Please mark this comment with :thumbsup: or :thumbsdown: to give our bot feedback!
+            Links: [app homepage](https://github.com/marketplace/issue-label-bot), [dashboard]({app_url}data/{repo_owner}/{repo_name}) and [code](https://github.com/hamelsmu/MLapp) for this bot.
+            """.format(labels="`, `".join(label_names),
+                       confidence=", ".join(["{:.2f}".format(p) for p in label_probabilities]),
+                       app_url=self.app_url,
+                       repo_owner=repo_owner,
+                       repo_name=repo_name)
+            # label the issue using the GitHub api
+            issue.add_labels(*label_names)
+            logging.info(f'Add `{"`, `".join(label_names)}` to the issue # {issue_num}')
+        else:
+            message = """Issue Label Bot is not confident enough to auto-label this issue.
+            See [dashboard]({app_url}data/{repo_owner}/{repo_name}) for more details.
+            """.format(app_url=self.app_url,
+                       repo_owner=repo_owner,
+                       repo_name=repo_name)
+            logging.warning(f'Not confident enough to label this issue: # {issue_num}')
+
+        # make a comment using the GitHub api
+        comment = issue.create_comment(message)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO,
+                        format=('%(levelname)s|%(asctime)s'
+                                '|%(message)s|%(pathname)s|%(lineno)d|'),
+                        datefmt='%Y-%m-%dT%H:%M:%S',
+                        )
+
+    fire.Fire(Worker)

--- a/py/label_microservice/worker.py
+++ b/py/label_microservice/worker.py
@@ -346,6 +346,8 @@ class Worker:
             label_names, label_probabilities = self.filter_specified_labels(repo_owner,
                                                                             repo_name,
                                                                             predictions)
+        else:
+            label_names = []
 
         # get the isssue handle
         issue = get_issue_handle(installation_id, repo_owner, repo_name, issue_num)


### PR DESCRIPTION
Design worker class
- allow mlpwrapper to load classifier from file
- add github util and app class
- add worker class to address pubsub event and do label prediction
- use fire to create entry point for worker
- update requirements.txt
- update embeddings to return issues even though they haven't been labeled


/assign @jlewi @zhenghuiwang @hamelsmu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/code-intelligence/41)
<!-- Reviewable:end -->
