### PR TITLE
Add exception handling to worker.py

### DIFF
--- a/py/label_microservice/worker.py
+++ b/py/label_microservice/worker.py
@@ -144,21 +144,27 @@ class Worker:
             issue_num = message.attributes['issue_num']
             logging.info(f'Receive issue #{issue_num} from {repo_owner}/{repo_name}')
 
-            # predict labels
-            self.load_yaml(repo_owner, repo_name)
-            self.download_model_from_gcs()
-            predictions, issue_embedding = self.predict_labels(repo_owner, repo_name, issue_num)
-            self.add_labels_to_issue(installation_id, repo_owner, repo_name,
-                                     issue_num, predictions)
+            try:
+                # predict labels
+                self.load_yaml(repo_owner, repo_name)
+                self.download_model_from_gcs()
+                predictions, issue_embedding = self.predict_labels(repo_owner, repo_name, issue_num)
+                self.add_labels_to_issue(installation_id, repo_owner, repo_name,
+                                         issue_num, predictions)
 
-            # log the prediction, which will be used to track the performance
-            log_dict = {
-                'repo_owner': repo_owner,
-                'repo_name': repo_name,
-                'issue_num': int(issue_num),
-                'labels': predictions['labels']
-            }
-            logging.info(log_dict)
+                # log the prediction, which will be used to track the performance
+                log_dict = {
+                    'repo_owner': repo_owner,
+                    'repo_name': repo_name,
+                    'issue_num': int(issue_num),
+                    'labels': predictions['labels']
+                }
+                logging.info(log_dict)
+
+            except Exception as e:
+                logging.error(f'Addressing issue #{issue_num} from {repo_owner}/{repo_name} causes an error')
+                logging.error(f'Error type: {type(e)}')
+                logging.error(e)
 
             # acknowledge the message, or pubsub will repeatedly attempt to deliver it
             message.ack()

--- a/py/label_microservice/worker.py
+++ b/py/label_microservice/worker.py
@@ -162,6 +162,9 @@ class Worker:
                 logging.info(log_dict)
 
             except Exception as e:
+                # hard to find out which errors should be handled differently (e.g., retrying for multiple times)
+                # and how to handle the error that the same message causes for multiple times
+                # so use generic exception to ignore all errors for now
                 logging.error(f'Addressing issue #{issue_num} from {repo_owner}/{repo_name} causes an error')
                 logging.error(f'Error type: {type(e)}')
                 logging.error(e)


### PR DESCRIPTION
This PR adds exception handling to the `callback` function in workers.
If there is any unexpected error, use the exception handling to log the error message and still acknowledge the message in Pub/Sub.
If there is an error and the worker does not acknowledge the message, the error will kill all pods that workers are running in because the message will be delivered to them sequentially.

/assign @jlewi @zhenghuiwang @hamelsmu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/code-intelligence/44)
<!-- Reviewable:end -->
