### PR TITLE
Check in the batch code.

### DIFF
--- a/py/code_intelligence/embeddings.py
+++ b/py/code_intelligence/embeddings.py
@@ -97,18 +97,18 @@ def get_all_issue_text(owner, repo, inf_wrapper, workers=64):
     features = []
     labels = []
     nums = []
+    issues_dict = {'title': [], 'body': []}
     for issue in tqdm(filtered_issues):
         labels.append(issue['labels'])
         nums.append(issue['num'])
-        # calculate embedding
-        text = inf_wrapper.process_dict(issue)['text']
-        feature = inf_wrapper.get_pooled_features(text).detach().cpu()
-        # only need the first 1600 dimensions
-        features.append(feature[:, :1600])
+        issues_dict['title'].append(issue['title'])
+        issues_dict['body'].append(issue['body'])
+
+    features = inf_wrapper.df_to_embedding(pd.DataFrame.from_dict(issues_dict))
 
     assert len(features) == len(labels), 'Error you have mismatch b/w number of observations and labels.'
 
-    return {'features':torch.cat(features).numpy(),
+    return {'features': features[:, :1600],
             'labels': labels,
             'nums': nums}
 


### PR DESCRIPTION
This PR is to check in the code using batching inference and fix error while doing batch inference.

The reason to update `inference.py` is that when we use batches, it may encounter CUDA out of memory error in the last few iterations because the distribution of the lengths of sentences may be a long tail.
I update the batch strategy to fix it. If the current batch causes the cuda out of memory error, the batch size will decrease to half of the original size.

/assign @jlewi 
/assign @zhenghuiwang 
/assign @hamelsmu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/code-intelligence/53)
<!-- Reviewable:end -->
