### PR TITLE
Use the Kubeflow DockerHub organization for the GitHub action for issue_triage

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -12,8 +12,8 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           echo ${PASSWORD} | docker login -u $USERNAME --password-stdin
-          docker build -t hamelsmu/kubeflow-triage -f Issue_Triage/Dockerfile .
-          docker push hamelsmu/kubeflow-triage
+          docker build -t kubeflow/kubeflow-triage -f Issue_Triage/Dockerfile .
+          docker push kubeflow/kubeflow-triage
         env:
           USERNAME: ${{ secrets.DOCKER_USERNAME }}
           PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/triage_issues.yaml
+++ b/.github/workflows/triage_issues.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update Kanban
-        uses: kubeflow/code-intelligence/Issue_Triage/action@test-triage-action
+        uses: kubeflow/code-intelligence/Issue_Triage/action@master
         with:
           # Letting input NEEDS_TRIAGE_PROJECT_CARD_ID use the default value
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/Issue_Triage/action/README.md
+++ b/Issue_Triage/action/README.md
@@ -35,4 +35,18 @@ jobs:
 2. **ISSUE_NUMBER**: The issue number in the current repo that you want to triage
 3. **GITHUB_PERSONAL_ACCESS_TOKEN**: A personal access token with authorization to modify the project board.
 
+### Installing the action on a repository
 
+1. Create a workflow like the one above in your repository in the directory
+
+   ```
+   .github/workflows/
+   ```
+
+1. Create a secret for the repository called `triage_projects_github_token` which has a GitHub personal access token with the following permissions
+
+   * admin:org read & write
+     * Needed to modify projects
+
+   * repo:public_repo
+      * needed to see issues

--- a/Issue_Triage/action/README.md
+++ b/Issue_Triage/action/README.md
@@ -1,5 +1,11 @@
 # Triage Issues For Kubeflow
-A GitHub Action that triages issues for the [Kubeflow](https://github.com/kubeflow/) project.
+A GitHub Action that automatically adds/removes issues from the Project [Needs Triage](https://github.com/orgs/kubeflow/projects/26)
+
+* Kubeflow's triage criterion are defined in [issue_triage.md](https://github.com/kubeflow/community/blob/master/proposals/issue_triage.md) 
+
+  * This doc provides more information about Kubeflow's process for triaging issues
+
+* The code for actually triaging issues is in [triage.py](https://github.com/kubeflow/code-intelligence/blob/master/py/issue_triage/triage.py)
 
 ## Discussion
 
@@ -40,13 +46,18 @@ jobs:
 1. Create a workflow like the one above in your repository in the directory
 
    ```
-   .github/workflows/
+   .github/workflows/<your_file_name>.yaml
    ```
 
-1. Create a secret for the repository called `triage_projects_github_token` which has a GitHub personal access token with the following permissions
+1. [Create a secret for the repository](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets) called `triage_projects_github_token` which has a [GitHub personal access token](https://github.com/settings/tokens) with the following permissions
 
    * admin:org read & write
      * Needed to modify projects
 
    * repo:public_repo
       * needed to see issues
+
+1. Kubeflow repositories should use the personal access token **issue-triage** for the **kubeflow-bot** GitHub account
+
+   * The access token is currently stored in Google's internal key management system
+   * The google team has access and can add the key to repositories as necessary

--- a/Issue_Triage/action/action.yml
+++ b/Issue_Triage/action/action.yml
@@ -17,4 +17,4 @@ branding:
   icon: 'check-square'
 runs:
   using: 'docker'
-  image: 'docker://hamelsmu/kubeflow-triage'
+  image: 'docker://kubeflow/kubeflow-triage'


### PR DESCRIPTION
* Instead of storing the image in a personal account we should use the kubeflow
  organization.

* Update the issue_triage.yaml workflow in this repository to use the master version of the action

* Related to kubeflow/code-intelligence#66
* Related to kubeflow/community#27 - GitHub action for adding issues to triage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/code-intelligence/67)
<!-- Reviewable:end -->
