### PR TITLE
Define classes to combine repository specific labels with the universal model for issue kind

### DIFF
--- a/py/label_microservice/combined_model.py
+++ b/py/label_microservice/combined_model.py
@@ -1,0 +1,53 @@
+"""A combined model combines multiple models."""
+
+import itertools
+import logging
+
+from label_microservice import models
+
+class CombinedLabelModels(models.IssueLabelModel):
+  """Generate predictions with multiple models and then combine the results"""
+
+  def __init__(self, models=None):
+    # A list of models to generate predictions
+    self._models = models
+
+  def predict_issue_labels(self, title:str , text:str):
+    """Return a dictionary of label probabilities.
+
+    Args:
+      title: The title for the issue
+      text: The text for the issue
+
+    Return
+    ------
+    dict: Dictionary of label to probability of that label for the
+      the issue str -> float
+    """
+    if not self._models:
+      raise ValueError("Can't generate predictions; no models loaded")
+
+    predictions = {}
+    for i, m in enumerate(self._models):
+      logging.info(f"Generating predictions with model {i}")
+
+      latest = m.predict_issue_labels(title, text)
+
+      predictions = self._combine_predictions(predictions, latest)
+
+    return predictions
+
+  @staticmethod
+  def _combine_predictions(left, right):
+    """Combine two sets of predictions by taking the max probability."""
+    results = {}
+    results.update(left)
+
+    for label, probability in right.items():
+      if not label in results:
+        results[label] = probability
+        continue
+
+      results[label] = max(left[label], right[label])
+
+    return results

--- a/py/label_microservice/combined_model_test.py
+++ b/py/label_microservice/combined_model_test.py
@@ -1,0 +1,43 @@
+"""Unittest for repo_specific_model. """
+import logging
+from unittest import mock
+import pytest
+
+from label_microservice import combined_model
+from label_microservice import test_util
+
+def test_combine_predictions():
+  """A unittest for combine predictions.
+  """
+  left = {
+    "a": .1,
+    "b": .9,
+    "c": .5,
+  }
+
+  right = {
+    "a": .9,
+    "b": .1,
+    "d": .6
+  }
+
+  actual = combined_model.CombinedLabelModels._combine_predictions(left, right)
+
+  expected = {
+    "a": .9,
+    "b": .9,
+    "c": .5,
+    "d": .6,
+  }
+  test_util.assert_dict_equal(expected, actual)
+
+if __name__ == "__main__":
+  logging.basicConfig(
+      level=logging.INFO,
+      format=('%(levelname)s|%(asctime)s'
+              '|%(pathname)s|%(lineno)d| %(message)s'),
+      datefmt='%Y-%m-%dT%H:%M:%S',
+  )
+  logging.getLogger().setLevel(logging.INFO)
+
+  pytest.main()

--- a/py/label_microservice/issue_label_predictor.py
+++ b/py/label_microservice/issue_label_predictor.py
@@ -1,0 +1,160 @@
+import logging
+import os
+
+from code_intelligence import embeddings
+from label_microservice import combined_model
+from label_microservice import repo_specific_model
+from label_microservice import universal_kind_label_model as universal_model
+
+UNIVERSAL_MODEL_NAME = "universal"
+
+def _combined_model_name(org, repo):
+  """Return the name of the combined model for a repo"""
+  return f"{org}/{repo}_combined"
+
+def _dict_has_keys(d, keys):
+  for k in keys:
+    if not k in d:
+      return False
+
+  return True
+
+class IssueLabelPredictor:
+  """Predict labels for an issue.
+
+  This class combines various model classes with logic to fetch information
+  about the issue.
+
+  This class doesn't attach the labels to the issues.
+  """
+
+  def __init__(self):
+
+    self._models = {}
+    self._load_models()
+
+  def _load_models(self):
+    logging.info("Loading the universal model")
+    self._models[UNIVERSAL_MODEL_NAME] = universal_model.UniversalKindLabelModel()
+
+    # TODO(jlewi): How should we get a list of all models for which we
+    # have repo specific models. mlbot is doing this based on a config
+    # file; https://github.com/machine-learning-apps/Issue-Label-Bot/blob/26d8fb65be3b39de244c4be9e32b2838111dac10/flask_app/forward_utils.py#L5
+    for org_and_repo in [("kubeflow", "kubeflow")]:
+      org = org_and_repo[0]
+      repo = org_and_repo[1]
+      logging.info(f"Loading model for repo {org}/{repo}")
+
+      repo_model = repo_specific_model.RepoSpecificLabelModel.from_repo(
+              org, repo,
+              embedding_api_endpoint=os.environ.get("ISSUE_EMBEDDING_SERVICE"))
+
+      self._models[f"{org}/{repo}"] = repo_model
+
+      combined = combined_model.CombinedLabelModels(
+              models=[self._models["universal"], repo_model])
+      self._models[_combined_model_name(org, repo)] = combined
+
+  def predict_labels_for_data(self, model_name, title, body):
+    """Generate label predictions for the specified data.
+
+    Args:
+      model_name: Which model to use
+      title: Title for the issue
+      body: body of the issue
+
+    Returns
+     dict: str -> float; dictionary mapping labels to their probability
+    """
+    if not model_name in self._models:
+      raise ValueError(f"No model named {model_name}")
+
+    model = self._models[model_name]
+    logging.info(f"Generating predictions for title={title} text={body}")
+    predictions = model.predict_issue_labels(title, body)
+
+    return predictions
+
+  def predict_labels_for_issue(self, org, repo, issue_number, model_name=None):
+    """Generate label predictions for a github issue.
+
+    The function contacts GitHub to collect the required data.
+
+    Args:
+      org: The GitHub organization
+      repo: The repo that owns the issue
+      number: The github issue number
+      model_name: (Optional) the name of the model to use to generate
+        predictions. if not supplied it is inferred based on the repository.
+
+    Returns
+     dict: str -> float; dictionary mapping labels to their probability
+    """
+    if not model_name:
+      repo_model = _combined_model_name(org, repo)
+
+      if repo_model in self._models:
+        model_name = repo_model
+      else:
+        model_name = UNIVERSAL_MODEL_NAME
+
+    logging.info(f"Predict labels for "
+                 f"{org}/{repo}#{issue_number} using "
+                 f"model {model_name}")
+
+    data = embeddings.get_issue_text(issue_number, None, org, repo)
+
+    if not data.get("title"):
+      logging.warning(f"Got empty title for {org}/{repo}#{issue_number}")
+
+    if not data.get("body"):
+      logging.warning(f"Got empty title for {org}/{repo}#{issue_number}")
+
+    predictions = self.predict_labels_for_data(
+      model_name, data.get("title"), data.get("body"))
+
+    return predictions
+
+  def predict(self, data):
+    """Generate predictions for the specified payload.
+
+    Args: data a dictionary containing the data to generate predictions for.
+    The payload can either look like
+
+        {
+          "title": "some issue title"
+          "text": "text for some issue
+          "model_name": Name of model to use
+          ...
+        }
+
+        in this case predictions will be generated for this title and text.
+
+        or
+
+        {
+          "repo_owner": <GitHub owner of the issue>
+          "repo_name": <GitHub repo>
+          "issue_num": <Issue number>
+          "model_name": (optional) name of the model to use
+          ...
+        }
+    """
+    text_keys = ["title", "text", "model_name"]
+    issue_keys = ["repo_owner", "repo_name", "issue_num"]
+    if _dict_has_keys(data, text_keys):
+      return self.predict_labels_for_data(data["model_name"], data["title"],
+                                          data["text"])
+    elif _dict_has_keys(data, issue_keys):
+      return self.predict_labels_for_issue(data["repo_owner"],
+                                           data["repo_name"],
+                                           data["issue_num"],
+                                           model_name=data.get("model_name"))
+    else:
+      actual = ",".join(data.keys())
+      text_str = ",".join(text_keys)
+      issue_str = ",".join(issue_keys)
+      want = f"[{text_str}] or [{issue_str}]"
+      logging.error(f"Data is missing required keys; got {actual}; want {want}")
+      raise ValueError(f"Data is missing required keys; got {actual}; want {want}")
+

--- a/py/label_microservice/models.py
+++ b/py/label_microservice/models.py
@@ -1,0 +1,22 @@
+"""The models packages defines wrappers around different models."""
+import abc
+
+class IssueLabelModel:
+  """A base class for all Issue label models.
+
+  This class defines a common interface for all issue label models.
+  """
+
+  @abc.abstractmethod
+  def predict_issue_labels(self, title:str , text:str ):
+    """Return a dictionary of label probabilities.
+
+    Args:
+      title: The title for the issue
+      text: The text for the issue
+
+    Return
+    ------
+    dict: Dictionary of label to probability of that label for the
+      the issue str -> float
+    """

--- a/py/label_microservice/repo_specific_model.py
+++ b/py/label_microservice/repo_specific_model.py
@@ -1,0 +1,167 @@
+"""Define a repo specific model."""
+
+import hashlib
+import logging
+import numpy as np
+import os
+import requests
+import yaml
+
+from code_intelligence import gcs_util
+from label_microservice import mlp
+from label_microservice import models
+from label_microservice import repo_config
+
+# The default endpoint for the microservice to compute embeddings
+DEFAULT_EMBEDDING_API_ENDPOINT = "http://issue-embedding-server"
+
+class RepoSpecificLabelModel(models.IssueLabelModel):
+  """A repo specific model using a multi-layer perceptron."""
+
+  def __init__(self):
+    self.config = None
+    self._mlp_predictor = None
+    self._embedding_api_endpoint = None
+    self._embedding_api_key = None
+
+    # A list of labels. The order of the labels corresponds to the order
+    # of the probabilities returned by the model
+    self._label_names = None
+    # Dictionary mapping label names to the probability thresholds.
+    self._label_thresholds = None
+
+  @classmethod
+  def from_repo(cls, repo_owner, repo_name, embedding_api_endpoint=None):
+    """Construct a model given the repo owner and name.
+
+    Load config from the YAML of the specific repo_owner/repo_name.
+
+    Args:
+      repo_owner: str
+      repo_name: str
+      embedding_api_endpoint: The endpoint for the microservice to compute
+        embeddings
+    """
+
+    model = RepoSpecificLabelModel()
+
+    model._embedding_api_endpoint = embedding_api_endpoint
+
+    model.config = repo_config.RepoConfig(repo_owner=repo_owner,
+                                          repo_name=repo_name)
+
+    # download model
+    gcs_util.download_file_from_gcs(model.config.model_bucket_name,
+                                    model.config.model_gcs_path,
+                                    model.config.model_local_path)
+
+    # download label columns
+    gcs_util.download_file_from_gcs(model.config.model_bucket_name,
+                                    model.config.labels_gcs_path,
+                                    model.config.labels_local_path)
+
+    model._mlp_predictor = mlp.MLPWrapper(
+      clf=None, model_file=model.config.model_local_path, load_from_model=True)
+
+    # Get label info.
+    # Expect a YAML file with a dictionary
+    # {'labels': list, 'probability_thresholds': {label_index: threshold}}
+    with open(model.config.labels_local_path, 'r') as f:
+      label_columns = yaml.safe_load(f)
+
+    model._label_names = label_columns["labels"]
+    model._label_thresholds = {}
+
+    for index, threshold in label_columns["probability_thresholds"].items():
+      model._label_thresholds[model._label_names[index]] = threshold
+
+    logging.info(f"Loaded model gs://{model.config.model_bucket_name}/"
+                 f"{model.config.model_gcs_path}")
+    logging.info(f"Loaded model config gs://{model.config.model_bucket_name}/"
+                 f"{model.config.labels_gcs_path}")
+    logging.info(f"Model label thresholds {model._label_thresholds}")
+    if not embedding_api_endpoint:
+      embedding_api_endpoint = DEFAULT_EMBEDDING_API_ENDPOINT
+
+    model._embedding_api_endpoint = embedding_api_endpoint
+    logging.info(f"Issue embedding service set to {model._embedding_api_endpoint}")
+    return model
+
+  def predict_issue_labels(self, title:str , text:str):
+    """Return a dictionary of label probabilities.
+
+    Args:
+      title: The title for the issue
+      text: The text for the issue
+
+    Return
+    ------
+    dict: Dictionary of label to probability of that label for the
+      the issue str -> float
+    """
+    issue_embedding = self._get_issue_embedding(title, text)
+
+    # if not retrieve the embedding, ignore to predict it
+    if issue_embedding is None:
+      logging.error("No embeddings returned for issue")
+      return {}
+
+    # change embedding from 1d to 2d for prediction and extract the result
+    label_probabilities = self._mlp_predictor.predict_probabilities(
+      [issue_embedding])[0]
+
+    # check thresholds to get labels that need to be predicted
+    predictions = dict(zip(self._label_names, label_probabilities))
+
+    # TODO(https://github.com/kubeflow/code-intelligence/issues/79):
+    # We should use some sort of context to pass along information
+    # about the issue so we can log what issue these predictions pertain
+    # to.
+    logging.info(f"Unfiltered predictions: {predictions}")
+
+    labels_to_remove = []
+    for label, probability in predictions.items():
+      # if the threshold of any label is None, just ignore it
+      # because the label does not meet both of precision & recall thresholds
+      if not self._label_thresholds[label]:
+        labels_to_remove.append(label)
+        continue
+
+      if probability < self._label_thresholds[label]:
+        labels_to_remove.append(label)
+
+    for l in labels_to_remove:
+      del predictions[l]
+    logging.info(f"Labels below precision and recall {labels_to_remove}")
+    return predictions
+
+  def _get_issue_embedding(self, title, text):
+    """Get the embedding of the issue by calling GitHub Issue
+    Embeddings API endpoint.
+
+    Args:
+      title: The title for the issue
+      text: The text for the issue
+
+    Return
+    ------
+    numpy.ndarray
+        shape: (1600,)
+    """
+    data = {'title': title, 'body': text}
+
+    # sending post request and saving response as response object
+    url = self._embedding_api_endpoint + "/text"
+    r = requests.post(url=url, json=data)
+    if r.status_code != 200:
+      logging.warning(f'Status code is {r.status_code} not 200: '
+                            'can not retrieve the embedding')
+      return None
+
+    # For debugging print out hash of the content embeddings. This is to
+    # see if they are changing
+    m = hashlib.md5()
+    m.update(r.content)
+    logging.info(f"hash of embeddings {m.hexdigest()}")
+    embeddings = np.frombuffer(r.content, dtype='<f4')[:1600]
+    return embeddings

--- a/py/label_microservice/repo_specific_model.py
+++ b/py/label_microservice/repo_specific_model.py
@@ -21,8 +21,7 @@ class RepoSpecificLabelModel(models.IssueLabelModel):
   def __init__(self):
     self.config = None
     self._mlp_predictor = None
-    self._embedding_api_endpoint = None
-    self._embedding_api_key = None
+    self._embedding_api_endpoint = DEFAULT_EMBEDDING_API_ENDPOINT
 
     # A list of labels. The order of the labels corresponds to the order
     # of the probabilities returned by the model

--- a/py/label_microservice/repo_specific_model.py
+++ b/py/label_microservice/repo_specific_model.py
@@ -110,6 +110,7 @@ class RepoSpecificLabelModel(models.IssueLabelModel):
     # with shape (n_samples, n_clasess) (for more info see
     # https://scikit-learn.org/stable/modules/generated/sklearn.neural_network.MLPClassifier.html#sklearn.neural_network.MLPClassifier.predict_proba)
     # We take the first row of this matrix because we only have 1 sample.
+    # Note: result[0] is essentially equivalent to result[0, :]
     label_probabilities = self._mlp_predictor.predict_probabilities(
       [issue_embedding])[0]
 

--- a/py/label_microservice/repo_specific_model.py
+++ b/py/label_microservice/repo_specific_model.py
@@ -106,8 +106,10 @@ class RepoSpecificLabelModel(models.IssueLabelModel):
       return {}
 
     # Predict probabilities expects a list of lists; i.e a 2-d matrix where
-    # each column is a different input vector. The output is also a list of
-    # lists but we extract the first list since we want a single output vector.
+    # each column is a different input vector. The output is an array
+    # with shape (n_samples, n_clasess) (for more info see
+    # https://scikit-learn.org/stable/modules/generated/sklearn.neural_network.MLPClassifier.html#sklearn.neural_network.MLPClassifier.predict_proba)
+    # We take the first row of this matrix because we only have 1 sample.
     label_probabilities = self._mlp_predictor.predict_probabilities(
       [issue_embedding])[0]
 

--- a/py/label_microservice/repo_specific_model.py
+++ b/py/label_microservice/repo_specific_model.py
@@ -106,11 +106,16 @@ class RepoSpecificLabelModel(models.IssueLabelModel):
       logging.error("No embeddings returned for issue")
       return {}
 
-    # change embedding from 1d to 2d for prediction and extract the result
+    # Predict probabilities expects a list of lists; i.e a 2-d matrix where
+    # each column is a different input vector. The output is also a list of
+    # lists but we extract the first list since we want a single output vector.
     label_probabilities = self._mlp_predictor.predict_probabilities(
       [issue_embedding])[0]
 
     # check thresholds to get labels that need to be predicted
+    # TODO(kubeflow/code-intelligence/issues/83): We should store the labels
+    # in the MLPClassifier to decrease the risk that they get out of sync
+    # with the probabilities.
     predictions = dict(zip(self._label_names, label_probabilities))
 
     # TODO(https://github.com/kubeflow/code-intelligence/issues/79):

--- a/py/label_microservice/repo_specific_model_test.py
+++ b/py/label_microservice/repo_specific_model_test.py
@@ -18,7 +18,10 @@ def test_predict_labels():
   model._mlp_predictor.predict_probabilities.return_value = [[.2, .9]]
 
   model._label_names = ["label1", "label2"]
-  model._label_thresholds = [.5 , .5]
+  model._label_thresholds = {
+    "label1": .5 ,
+    "label2": .5
+  }
   model._get_issue_embedding = mock.MagicMock()
   model._get_issue_embedding.return_value = [(10, 10)]
 

--- a/py/label_microservice/repo_specific_model_test.py
+++ b/py/label_microservice/repo_specific_model_test.py
@@ -1,0 +1,54 @@
+"""Unittest for repo_specific_model. """
+import logging
+from unittest import mock
+import pytest
+
+from label_microservice import mlp
+from label_microservice import repo_specific_model
+from label_microservice import test_util
+
+def test_predict_labels():
+  """A unittest for predict labels.
+
+  This function mocks out the embedding service and the MLPWorker.
+  """
+  model = repo_specific_model.RepoSpecificLabelModel()
+
+  model._mlp_predictor = mock.MagicMock(spec=mlp.MLPWrapper)
+  model._mlp_predictor.predict_probabilities.return_value = [[.2, .9]]
+
+  model._label_names = ["label1", "label2"]
+  model._label_thresholds = [.5 , .5]
+  model._get_issue_embedding = mock.MagicMock()
+  model._get_issue_embedding.return_value = [(10, 10)]
+
+  results = model.predict_issue_labels("some title", "some text")
+
+  expected = {
+    "label2": .9,
+  }
+  test_util.assert_dict_equal(expected, results)
+
+
+@mock.patch("repo_specific_model.requests.post")
+def test_get_issue_embedding_not_found(mock_post):
+  "Testing get_issue_embedding function when embedding service returns 404."""
+
+  model = repo_specific_model.RepoSpecificLabelModel()
+  model._embedding_api_key = "1234abcd"
+  mock_post.return_value.status_code = 404
+  issue_embedding = model._get_issue_embedding("title", "text")
+  # issue_embedding should be None
+  assert not issue_embedding
+
+if __name__ == "__main__":
+  logging.basicConfig(
+      level=logging.INFO,
+      format=('%(levelname)s|%(asctime)s'
+              '|%(pathname)s|%(lineno)d| %(message)s'),
+      datefmt='%Y-%m-%dT%H:%M:%S',
+  )
+  logging.getLogger().setLevel(logging.INFO)
+
+  pytest.main()
+

--- a/py/label_microservice/test_util.py
+++ b/py/label_microservice/test_util.py
@@ -1,0 +1,14 @@
+def assert_dict_equal(expected, actual):
+  message = []
+  equal = True
+  for k, v in expected.items():
+    if actual[k] != v:
+      message.append(f"For key {k} want {v}, got {actual[k]}")
+      equal = False
+
+  for k, v in actual.items():
+    if not k in expected:
+      message.append(f"Got extra key {k} with value {v}")
+      equal = False
+
+  assert equal, "\n".join(message)

--- a/py/label_microservice/universal_kind_label_model.py
+++ b/py/label_microservice/universal_kind_label_model.py
@@ -1,0 +1,79 @@
+
+import tensorflow as tf
+from tensorflow.keras import models as keras_models
+from tensorflow.keras import utils as keras_utils
+
+import dill as dpickle
+
+from urllib.request import urlopen
+from label_microservice import models
+
+class UniversalKindLabelModel(models.IssueLabelModel):
+  """UniversalKindLabelModel is a universal model that is trained across all repos.
+
+  The model predicts the kind for an issue.
+  """
+  def __init__(self,  class_names=['bug', 'feature', 'question']):
+    """Instantiate the model.
+
+    Args:
+      class_names: The specific label names to use for the three classes.
+    """
+    super(UniversalKindLabelModel, self).__init__()
+
+    # TODO(jlewi): We should probably parameterize the models rather than
+    # hardcoding it.
+    title_pp_url = "https://storage.googleapis.com/codenet/issue_labels/issue_label_model_files/title_pp.dpkl"
+    body_pp_url = 'https://storage.googleapis.com/codenet/issue_labels/issue_label_model_files/body_pp.dpkl'
+    model_url = 'https://storage.googleapis.com/codenet/issue_labels/issue_label_model_files/Issue_Label_v1_best_model.hdf5'
+    model_filename = 'downloaded_model.hdf5'
+
+    with urlopen(title_pp_url) as f:
+        self.title_pp = dpickle.load(f)
+
+    with urlopen(body_pp_url) as f:
+        self.body_pp = dpickle.load(f)
+
+    model_path = keras_utils.get_file(fname=model_filename, origin=model_url)
+
+    # TODO(jlewi): Is this right? Do we want to get the default graph or
+    # create a new graph? What happens when we are loading multiple graphs
+    # at once into memory.
+    self._graph =  tf.Graph()
+    with self._graph.as_default():
+      self.model = keras_models.load_model(model_path)
+
+    self.class_names = class_names
+
+  def predict_issue_labels(self,  title:str, body:str):
+    """
+    Get probabilities for the each class.
+
+    Parameters
+    ----------
+    title: str
+        the issue title
+    body: str
+       the issue body
+
+    Returns
+    ------
+    Dict[str:float]
+
+    Example
+    -------
+    >>> issue_labeler = IssueLabeler(body_pp, title_pp, model)
+    >>> issue_labeler.get_probabilities('hello world', 'hello world')
+    {'bug': 0.08372017741203308,
+     'feature': 0.6401631832122803,
+     'question': 0.2761166989803314}
+    """
+    #transform raw text into array of ints
+    vec_body = self.body_pp.transform([body])
+    vec_title = self.title_pp.transform([title])
+
+    # make predictions with the model
+    with self._graph.as_default():
+      probs = self.model.predict(x=[vec_body, vec_title]).tolist()[0]
+
+    return {k:v for k,v in zip(self.class_names, probs)}


### PR DESCRIPTION
* To combine multiple models we define a base class IssueLabelModel
  that defines a common interface for all the models.

  * This way different models can just implement that interface and we
    can easily combine the results.

* UniveralKindLabelModel will be used for the generic model to predict
  label kind that is trained on all repositories.

  * The UniversalKindLabelModel class is based on the IssueLabeler code
    https://github.com/machine-learning-apps/Issue-Label-Bot/blob/536e8bf4928b03d522dd021c0464587747e90a87/flask_app/utils.py#L67

* repo_specific_model.py contains a model class for predicting labels
  using a repo specific model.

  * Most of the code was previously inside worker.py
  * We wrap this code in the newly defined model interface so we can easily
    combine different models.

  * Subsequent PR wil update worker.py to use the new code

* Copy unittest functions from test_worker and into repo_specific_mode_test.py

* Change the signature of functions from (owner, repo, issue_num) to
  (title, text)

  * We want to be able to generate predictions using multiple models but we
    only want to make calls to the GitHub API to fetch issue information once.

  * So we should do the fetching from GitHub upstream of the prediction
    functions.

* Related to: kubeflow/code-intelligence#70 Combine multiple models

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/code-intelligence/82)
<!-- Reviewable:end -->
