### PR TITLE
label bot config should alias feature -> kind/feature

### DIFF
--- a/.github/issue_label_bot.yaml
+++ b/.github/issue_label_bot.yaml
@@ -1,4 +1,5 @@
 label-alias:
   bug: 'kind/bug'
+  feature: 'kind/feature'
   feature_request: 'kind/feature'
   question: 'kind/question'

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ fairing/__pycache__/**
 **/__pycache__/**
 *.pyc
 py/code_intelligence/.data/**
+
+# TODO(jlewi): Is this a remote module? Why is the fairing src getting cloned here?
+Label_Microservice/src/**


### PR DESCRIPTION
* We want the label bot to use the label "kind/feature" for feature issues

* Update the .gitignore file with some paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/code-intelligence/94)
<!-- Reviewable:end -->
