### PR TITLE
Add pytz to the requirements for the GitHub triage action image.

### DIFF
--- a/Issue_Triage/README.md
+++ b/Issue_Triage/README.md
@@ -1,0 +1,7 @@
+# Issue Triage
+
+# Action
+
+The Dockerfile is for the GitHub action to automatically add/remove issues from the needs Triage Kanban board.
+
+There is a GitHub action to automatically build and push the image.

--- a/Issue_Triage/requirements.txt
+++ b/Issue_Triage/requirements.txt
@@ -1,4 +1,5 @@
 fire>=0.1.3
 github3.py>=1.3.0
 numpy>=1.16.4
+pytz>=2019.1
 retrying>=1.3.3


### PR DESCRIPTION
* Related to: #96 action is failing with import error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/code-intelligence/97)
<!-- Reviewable:end -->
