### PR TITLE
Create a notebook to compute stats about label bot.

### DIFF
--- a/Issue_Triage/notebooks/metrics.ipynb
+++ b/Issue_Triage/notebooks/metrics.ipynb
@@ -432,17 +432,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 314,
+   "execution_count": 316,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-91b4cd12e56143c4b88db860c04a8c51\"></div>\n",
+       "<div id=\"altair-viz-fc20cd2740164d27b694b30edf4d2385\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  (function(spec, embedOpt){\n",
-       "    const outputDiv = document.getElementById(\"altair-viz-91b4cd12e56143c4b88db860c04a8c51\");\n",
+       "    const outputDiv = document.getElementById(\"altair-viz-fc20cd2740164d27b694b30edf4d2385\");\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
        "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
@@ -483,14 +483,14 @@
        "        .catch(showError)\n",
        "        .then(() => displayChart(vegaEmbed));\n",
        "    }\n",
-       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"layer\": [{\"mark\": \"line\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}, \"selection\": {\"selector013\": {\"type\": \"interval\", \"bind\": \"scales\", \"encodings\": [\"x\", \"y\"]}}}, {\"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}}], \"data\": {\"name\": \"data-bcab1200d103f404c02e000cf7142a4c\"}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-bcab1200d103f404c02e000cf7142a4c\": [{\"day\": \"2020-01-03T00:00:00\", \"num_issues\": 5}, {\"day\": \"2020-01-17T00:00:00\", \"num_issues\": 10}, {\"day\": \"2020-01-18T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-19T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-20T00:00:00\", \"num_issues\": 7}]}}, {\"mode\": \"vega-lite\"});\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"layer\": [{\"mark\": \"line\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}}, {\"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}}], \"data\": {\"name\": \"data-bcab1200d103f404c02e000cf7142a4c\"}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-bcab1200d103f404c02e000cf7142a4c\": [{\"day\": \"2020-01-03T00:00:00\", \"num_issues\": 5}, {\"day\": \"2020-01-17T00:00:00\", \"num_issues\": 10}, {\"day\": \"2020-01-18T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-19T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-20T00:00:00\", \"num_issues\": 7}]}}, {\"mode\": \"vega-lite\"});\n",
        "</script>"
       ],
       "text/plain": [
        "alt.LayerChart(...)"
       ]
      },
-     "execution_count": 314,
+     "execution_count": 316,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -504,7 +504,9 @@
     "\n",
     "point = line + line.mark_point()\n",
     "\n",
-    "point.interactive()"
+    "# Try turning off interactive mode to see if it renders in GitHub preview.\n",
+    "point\n",
+    "# point.interactive()"
    ]
   }
  ],

--- a/Issue_Triage/notebooks/metrics.ipynb
+++ b/Issue_Triage/notebooks/metrics.ipynb
@@ -1,0 +1,520 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Analyze Issue Label Bot\n",
+    "\n",
+    "* This notebook is used to compute metrics to evaluate performance of the issue label bot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 173,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import altair as alt\n",
+    "import collections\n",
+    "import importlib\n",
+    "import logging\n",
+    "import sys\n",
+    "import os\n",
+    "import datetime\n",
+    "from dateutil import parser as dateutil_parser\n",
+    "import glob\n",
+    "import json\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from pandas.io import gbq\n",
+    "\n",
+    "# A bit of a hack to set the path correctly\n",
+    "sys.path = [os.path.abspath(os.path.join(os.getcwd(), \"..\", \"..\", \"py\"))] + sys.path\n",
+    "\n",
+    "logging.basicConfig(level=logging.INFO,\n",
+    "                  format=('%(levelname)s|%(asctime)s'\n",
+    "                        '|%(message)s|%(pathname)s|%(lineno)d|'),\n",
+    "                datefmt='%Y-%m-%dT%H:%M:%S',\n",
+    "                )\n",
+    "logging.getLogger().setLevel(logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 174,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import subprocess\n",
+    "# Configuration Variables. Modify as desired.\n",
+    "\n",
+    "PROJECT = subprocess.check_output([\"gcloud\", \"config\", \"get-value\", \"project\"]).strip().decode()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup Authorization\n",
+    "\n",
+    "If you are using a service account run\n",
+    "%%bash\n",
+    "\n",
+    "# Activate Service Account provided by Kubeflow.\n",
+    "gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}\n",
+    "\n",
+    "If you are running using user credentials\n",
+    "\n",
+    "gcloud auth application-default login"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Query Bigquery\n",
+    "\n",
+    "* We need to query bigquery to get the issues were we added predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 201,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"\"\"\n",
+    "SELECT\n",
+    "    timestamp,\n",
+    "    jsonPayload.repo_owner, \n",
+    "    jsonPayload.repo_name,\n",
+    "    cast(jsonPayload.issue_num as numeric) as issue_num,\n",
+    "    jsonPayload.predictions\n",
+    "  FROM `issue-label-bot-dev.issue_label_bot_logs_dev.stderr_*`\n",
+    "  where jsonPayload.message = \"Add labels to issue.\"\n",
+    "\"\"\"\n",
+    "\n",
+    "labeled=gbq.read_gbq(str(query), dialect='standard', project_id=PROJECT)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 214,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Count how many times each label was added\n",
+    "label_counts = collections.defaultdict(lambda: 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 215,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We need to compute the number of issues that got labeled with an area or kind label\n",
+    "results = pd.DataFrame(index=range(labeled.shape[0]), columns=[\"area\", \"kind\"])\n",
+    "results = results.fillna(0)\n",
+    "\n",
+    "for i in range(labeled.shape[0]):    \n",
+    "    predictions = labeled[\"predictions\"][i]\n",
+    "    \n",
+    "    if not predictions:\n",
+    "        continue\n",
+    "        \n",
+    "    # Loop over the predictions to see if one of them includes an area or kind label\n",
+    "    for l, p in predictions.items():\n",
+    "        label_counts[l] = label_counts[l] + 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 247,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now for each issue count whether a particular label is added\n",
+    "issue_labels = pd.DataFrame(index=range(labeled.shape[0]), columns=label_counts.keys())\n",
+    "issue_labels = issue_labels.fillna(0)\n",
+    "\n",
+    "for c in [\"repo_owner\", \"repo_name\", \"issue_num\"]:\n",
+    "    issue_labels[c] = labeled[c]\n",
+    "\n",
+    "for i in range(labeled.shape[0]):\n",
+    "    predictions = labeled[\"predictions\"][i]\n",
+    "    \n",
+    "    if not predictions:\n",
+    "        continue\n",
+    "    \n",
+    "    for l, p in predictions.items():\n",
+    "        if not p:\n",
+    "            continue\n",
+    "            \n",
+    "        issue_labels.at[i, l] = 1\n",
+    "        \n",
+    "# Deduplicate the rows\n",
+    "# We need to group by (repo_owner, repo_name, issue_num); we should take the max of each column\n",
+    "# as a way of dealing with duplicates\n",
+    "issue_labels = issue_labels.groupby([\"repo_owner\", \"repo_name\", \"issue_num\"], as_index=False).max()        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 248,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a mapping from label prefixes to all all the labels with that prefix\n",
+    "# e.g. area -> [\"area_jupyter\", \"area_kfctl\", ...]\n",
+    "\n",
+    "label_prefixes = collections.defaultdict(lambda: [])\n",
+    "\n",
+    "for l in label_counts.keys():\n",
+    "    pieces = l.split(\"_\")\n",
+    "    if len(pieces) <= 1:\n",
+    "        continue\n",
+    "        \n",
+    "    label_prefixes[pieces[0]] = label_prefixes[pieces[0]] + [l]\n",
+    "    \n",
+    "# Add remappings.\n",
+    "# The log entries associated with \"Add labels to issue.\" log the model predictions before label remapping\n",
+    "# is applied; i.e. before feature is remapped to kind/feature.\n",
+    "# So we want to apply those mappings here before computing the stats.\n",
+    "#\n",
+    "# TODO(https://github.com/kubeflow/code-intelligence/issues/109): We should arguably load these from\n",
+    "# the YAML files configuring label bot.\n",
+    "for l in [\"bug\", \"feature\", \"feature_request\", \"question\"]:\n",
+    "    if l not in label_counts.keys():\n",
+    "        continue\n",
+    "    label_prefixes[\"kind\"] = label_prefixes[\"kind\"] + [l]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 249,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now for each issue aggregate across all labels with a given prefix to see if the issue has at least one\n",
+    "# of the given prefix labels\n",
+    "issue_group_labels =  pd.DataFrame(index=range(issue_labels.shape[0]), columns=label_prefixes.keys())\n",
+    "issue_group_labels = issue_group_labels.fillna(0)\n",
+    "\n",
+    "for c in [\"repo_owner\", \"repo_name\", \"issue_num\"]:\n",
+    "    issue_group_labels[c] = issue_labels[c]\n",
+    "\n",
+    "for prefix, labels in label_prefixes.items():\n",
+    "    issue_group_labels[prefix] = issue_labels[labels].max(axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 254,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute the number of issues with at least one of the specified prefixes\n",
+    "rows = [\"area\", \"platform\", \"kind\"]\n",
+    "num_issues = issue_group_labels.shape[0]\n",
+    "counts = issue_group_labels[rows].sum(axis=0)\n",
+    "stats = pd.DataFrame(index=range(len(rows)), columns = [\"label\", \"count\", \"percentage\"])\n",
+    "stats[\"label\"] = counts.index\n",
+    "stats[\"count\"] = counts.values\n",
+    "stats[\"percentage\"] = stats[\"count\"]/float(num_issues) *100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 255,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total # of issues 24\n",
+      "Number and precentage of issues with labels with various prefixes\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>label</th>\n",
+       "      <th>count</th>\n",
+       "      <th>percentage</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>area</td>\n",
+       "      <td>1</td>\n",
+       "      <td>4.166667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>platform</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>kind</td>\n",
+       "      <td>23</td>\n",
+       "      <td>95.833333</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      label  count  percentage\n",
+       "0      area      1    4.166667\n",
+       "1  platform      0    0.000000\n",
+       "2      kind     23   95.833333"
+      ]
+     },
+     "execution_count": 255,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(f\"Total # of issues {num_issues}\")\n",
+    "print(\"Number and precentage of issues with labels with various prefixes\")\n",
+    "stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 256,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div id=\"altair-viz-73940143ee8344fab6161edc5c7b660f\"></div>\n",
+       "<script type=\"text/javascript\">\n",
+       "  (function(spec, embedOpt){\n",
+       "    const outputDiv = document.getElementById(\"altair-viz-73940143ee8344fab6161edc5c7b660f\");\n",
+       "    const paths = {\n",
+       "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
+       "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
+       "      \"vega-lite\": \"https://cdn.jsdelivr.net/npm//vega-lite@4.0.2?noext\",\n",
+       "      \"vega-embed\": \"https://cdn.jsdelivr.net/npm//vega-embed@6?noext\",\n",
+       "    };\n",
+       "\n",
+       "    function loadScript(lib) {\n",
+       "      return new Promise(function(resolve, reject) {\n",
+       "        var s = document.createElement('script');\n",
+       "        s.src = paths[lib];\n",
+       "        s.async = true;\n",
+       "        s.onload = () => resolve(paths[lib]);\n",
+       "        s.onerror = () => reject(`Error loading script: ${paths[lib]}`);\n",
+       "        document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
+       "      });\n",
+       "    }\n",
+       "\n",
+       "    function showError(err) {\n",
+       "      outputDiv.innerHTML = `<div class=\"error\" style=\"color:red;\">${err}</div>`;\n",
+       "      throw err;\n",
+       "    }\n",
+       "\n",
+       "    function displayChart(vegaEmbed) {\n",
+       "      vegaEmbed(outputDiv, spec, embedOpt)\n",
+       "        .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));\n",
+       "    }\n",
+       "\n",
+       "    if(typeof define === \"function\" && define.amd) {\n",
+       "      requirejs.config({paths});\n",
+       "      require([\"vega-embed\"], displayChart, err => showError(`Error loading script: ${err.message}`));\n",
+       "    } else if (typeof vegaEmbed === \"function\") {\n",
+       "      displayChart(vegaEmbed);\n",
+       "    } else {\n",
+       "      loadScript(\"vega\")\n",
+       "        .then(() => loadScript(\"vega-lite\"))\n",
+       "        .then(() => loadScript(\"vega-embed\"))\n",
+       "        .catch(showError)\n",
+       "        .then(() => displayChart(vegaEmbed));\n",
+       "    }\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-4451d8e017c39fe7d73f407358e493ab\"}, \"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"nominal\", \"field\": \"label\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"count\"}}, \"selection\": {\"selector003\": {\"type\": \"interval\", \"bind\": \"scales\", \"encodings\": [\"x\", \"y\"]}}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-4451d8e017c39fe7d73f407358e493ab\": [{\"label\": \"area\", \"count\": 1, \"percentage\": 4.166666666666666}, {\"label\": \"platform\", \"count\": 0, \"percentage\": 0.0}, {\"label\": \"kind\", \"count\": 23, \"percentage\": 95.83333333333334}]}}, {\"mode\": \"vega-lite\"});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "alt.Chart(...)"
+      ]
+     },
+     "execution_count": 256,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chart = alt.Chart(stats)\n",
+    "chart.mark_point().encode(\n",
+    "  x='label',\n",
+    "  y='count',\n",
+    ").interactive()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Number of Issues Labeled Per Day\n",
+    "\n",
+    "* Make a plot of the number of issues labeled each day"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 300,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.7/dist-packages/ipykernel_launcher.py:8: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
+      "  \n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "issues_per_day = labeled[[\"timestamp\",\"repo_owner\", \"repo_name\", \"issue_num\"]]\n",
+    "# Deduplicate the issues by taking the first entry\n",
+    "issues_per_day =  issues_per_day.groupby([\"repo_owner\", \"repo_name\", \"issue_num\"], as_index=False).min()\n",
+    "# Compute the day \n",
+    "issues_per_day[\"day\"] = issues_per_day[\"timestamp\"].apply(lambda x: datetime.datetime(x.year, x.month, x.day))\n",
+    "issue_counts = issues_per_day[[\"day\"]]\n",
+    "issue_counts[\"num_issues\"] = 1\n",
+    "issue_counts = issue_counts.groupby([\"day\"], as_index=False).sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 311,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<div id=\"altair-viz-5ec3300b9a35412b821528a49bc39fdf\"></div>\n",
+       "<script type=\"text/javascript\">\n",
+       "  (function(spec, embedOpt){\n",
+       "    const outputDiv = document.getElementById(\"altair-viz-5ec3300b9a35412b821528a49bc39fdf\");\n",
+       "    const paths = {\n",
+       "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
+       "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
+       "      \"vega-lite\": \"https://cdn.jsdelivr.net/npm//vega-lite@4.0.2?noext\",\n",
+       "      \"vega-embed\": \"https://cdn.jsdelivr.net/npm//vega-embed@6?noext\",\n",
+       "    };\n",
+       "\n",
+       "    function loadScript(lib) {\n",
+       "      return new Promise(function(resolve, reject) {\n",
+       "        var s = document.createElement('script');\n",
+       "        s.src = paths[lib];\n",
+       "        s.async = true;\n",
+       "        s.onload = () => resolve(paths[lib]);\n",
+       "        s.onerror = () => reject(`Error loading script: ${paths[lib]}`);\n",
+       "        document.getElementsByTagName(\"head\")[0].appendChild(s);\n",
+       "      });\n",
+       "    }\n",
+       "\n",
+       "    function showError(err) {\n",
+       "      outputDiv.innerHTML = `<div class=\"error\" style=\"color:red;\">${err}</div>`;\n",
+       "      throw err;\n",
+       "    }\n",
+       "\n",
+       "    function displayChart(vegaEmbed) {\n",
+       "      vegaEmbed(outputDiv, spec, embedOpt)\n",
+       "        .catch(err => showError(`Javascript Error: ${err.message}<br>This usually means there's a typo in your chart specification. See the javascript console for the full traceback.`));\n",
+       "    }\n",
+       "\n",
+       "    if(typeof define === \"function\" && define.amd) {\n",
+       "      requirejs.config({paths});\n",
+       "      require([\"vega-embed\"], displayChart, err => showError(`Error loading script: ${err.message}`));\n",
+       "    } else if (typeof vegaEmbed === \"function\") {\n",
+       "      displayChart(vegaEmbed);\n",
+       "    } else {\n",
+       "      loadScript(\"vega\")\n",
+       "        .then(() => loadScript(\"vega-lite\"))\n",
+       "        .then(() => loadScript(\"vega-embed\"))\n",
+       "        .catch(showError)\n",
+       "        .then(() => displayChart(vegaEmbed));\n",
+       "    }\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"layer\": [{\"mark\": \"line\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}, \"selection\": {\"selector011\": {\"type\": \"interval\", \"bind\": \"scales\", \"encodings\": [\"x\", \"y\"]}}}, {\"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}}], \"data\": {\"name\": \"data-bcab1200d103f404c02e000cf7142a4c\"}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-bcab1200d103f404c02e000cf7142a4c\": [{\"day\": \"2020-01-03T00:00:00\", \"num_issues\": 5}, {\"day\": \"2020-01-17T00:00:00\", \"num_issues\": 10}, {\"day\": \"2020-01-18T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-19T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-20T00:00:00\", \"num_issues\": 7}]}}, {\"mode\": \"vega-lite\"});\n",
+       "</script>"
+      ],
+      "text/plain": [
+       "alt.LayerChart(...)"
+      ]
+     },
+     "execution_count": 311,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chart = alt.Chart(issue_counts)\n",
+    "line = chart.mark_line().encode(\n",
+    "  x=alt.X('day'),\n",
+    "  y=alt.Y('num_issues'),\n",
+    ")\n",
+    "\n",
+    "point = line + line.mark_point()\n",
+    "\n",
+    "point.interactive()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5rc1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Issue_Triage/notebooks/metrics.ipynb
+++ b/Issue_Triage/notebooks/metrics.ipynb
@@ -11,9 +11,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": 312,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "RendererRegistry.enable('html')"
+      ]
+     },
+     "execution_count": 312,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import altair as alt\n",
     "import collections\n",
@@ -37,7 +48,8 @@
     "                        '|%(message)s|%(pathname)s|%(lineno)d|'),\n",
     "                datefmt='%Y-%m-%dT%H:%M:%S',\n",
     "                )\n",
-    "logging.getLogger().setLevel(logging.INFO)"
+    "logging.getLogger().setLevel(logging.INFO)\n",
+    "alt.renderers.enable('html')"
    ]
   },
   {
@@ -308,17 +320,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 256,
+   "execution_count": 313,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-73940143ee8344fab6161edc5c7b660f\"></div>\n",
+       "<div id=\"altair-viz-d251d2f8fc924987bdcde6785869f627\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  (function(spec, embedOpt){\n",
-       "    const outputDiv = document.getElementById(\"altair-viz-73940143ee8344fab6161edc5c7b660f\");\n",
+       "    const outputDiv = document.getElementById(\"altair-viz-d251d2f8fc924987bdcde6785869f627\");\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
        "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
@@ -359,14 +371,14 @@
        "        .catch(showError)\n",
        "        .then(() => displayChart(vegaEmbed));\n",
        "    }\n",
-       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-4451d8e017c39fe7d73f407358e493ab\"}, \"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"nominal\", \"field\": \"label\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"count\"}}, \"selection\": {\"selector003\": {\"type\": \"interval\", \"bind\": \"scales\", \"encodings\": [\"x\", \"y\"]}}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-4451d8e017c39fe7d73f407358e493ab\": [{\"label\": \"area\", \"count\": 1, \"percentage\": 4.166666666666666}, {\"label\": \"platform\", \"count\": 0, \"percentage\": 0.0}, {\"label\": \"kind\", \"count\": 23, \"percentage\": 95.83333333333334}]}}, {\"mode\": \"vega-lite\"});\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-4451d8e017c39fe7d73f407358e493ab\"}, \"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"nominal\", \"field\": \"label\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"count\"}}, \"selection\": {\"selector012\": {\"type\": \"interval\", \"bind\": \"scales\", \"encodings\": [\"x\", \"y\"]}}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-4451d8e017c39fe7d73f407358e493ab\": [{\"label\": \"area\", \"count\": 1, \"percentage\": 4.166666666666666}, {\"label\": \"platform\", \"count\": 0, \"percentage\": 0.0}, {\"label\": \"kind\", \"count\": 23, \"percentage\": 95.83333333333334}]}}, {\"mode\": \"vega-lite\"});\n",
        "</script>"
       ],
       "text/plain": [
        "alt.Chart(...)"
       ]
      },
-     "execution_count": 256,
+     "execution_count": 313,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -420,17 +432,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 311,
+   "execution_count": 314,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-5ec3300b9a35412b821528a49bc39fdf\"></div>\n",
+       "<div id=\"altair-viz-91b4cd12e56143c4b88db860c04a8c51\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  (function(spec, embedOpt){\n",
-       "    const outputDiv = document.getElementById(\"altair-viz-5ec3300b9a35412b821528a49bc39fdf\");\n",
+       "    const outputDiv = document.getElementById(\"altair-viz-91b4cd12e56143c4b88db860c04a8c51\");\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
        "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
@@ -471,14 +483,14 @@
        "        .catch(showError)\n",
        "        .then(() => displayChart(vegaEmbed));\n",
        "    }\n",
-       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"layer\": [{\"mark\": \"line\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}, \"selection\": {\"selector011\": {\"type\": \"interval\", \"bind\": \"scales\", \"encodings\": [\"x\", \"y\"]}}}, {\"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}}], \"data\": {\"name\": \"data-bcab1200d103f404c02e000cf7142a4c\"}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-bcab1200d103f404c02e000cf7142a4c\": [{\"day\": \"2020-01-03T00:00:00\", \"num_issues\": 5}, {\"day\": \"2020-01-17T00:00:00\", \"num_issues\": 10}, {\"day\": \"2020-01-18T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-19T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-20T00:00:00\", \"num_issues\": 7}]}}, {\"mode\": \"vega-lite\"});\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"layer\": [{\"mark\": \"line\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}, \"selection\": {\"selector013\": {\"type\": \"interval\", \"bind\": \"scales\", \"encodings\": [\"x\", \"y\"]}}}, {\"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}}], \"data\": {\"name\": \"data-bcab1200d103f404c02e000cf7142a4c\"}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-bcab1200d103f404c02e000cf7142a4c\": [{\"day\": \"2020-01-03T00:00:00\", \"num_issues\": 5}, {\"day\": \"2020-01-17T00:00:00\", \"num_issues\": 10}, {\"day\": \"2020-01-18T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-19T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-20T00:00:00\", \"num_issues\": 7}]}}, {\"mode\": \"vega-lite\"});\n",
        "</script>"
       ],
       "text/plain": [
        "alt.LayerChart(...)"
       ]
      },
-     "execution_count": 311,
+     "execution_count": 314,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
* The statics are based off data logged by the worker. The logs are
  dumped into BigQuery.

* We use the logs to compute statistics about how many issues were
  assigned a kind, area, or platform label. This gives us a good
  proxy for the amount of toil saved.

* Include a plot of the number of issues per day.

Related to #71: Notebook to compute issue stats

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/code-intelligence/111)
<!-- Reviewable:end -->
