### PR TITLE
Create token getter classes for GitHub.

### DIFF
--- a/py/code_intelligence/github_app.py
+++ b/py/code_intelligence/github_app.py
@@ -340,9 +340,9 @@ class GitHubAppTokenGenerator:
         if now > self._token.expires_at:
             logging.info(f"Refreshing access token")
 
-            owner, name = repo.split("/")
+            owner, name = self._repo.split("/")
 
-            installation_id = self._app.get_installation_id(owner, repo)
+            installation_id = self._app.get_installation_id(owner, name)
 
             url = f'https://api.github.com/app/installations/{installation_id}/access_tokens'
             headers = {'Authorization': f'Bearer {self._app.get_jwt().decode()}',
@@ -352,8 +352,9 @@ class GitHubAppTokenGenerator:
             if response.status_code != 201:
                 raise Exception(f'Status code : {response.status_code}, {response.json()}')
 
-            token = response.json()['token']
-            expires_at = date_parser.parse(token['expires_at'])
+            response_json = response.json()
+            token = response_json['token']
+            expires_at = date_parser.parse(response_json['expires_at'])
             self._token = GITHUB_ACCESS_TOKEN(token, expires_at)
 
         return self._token
@@ -361,7 +362,8 @@ class GitHubAppTokenGenerator:
     def auth_headers(self):
         """Generate headers to attach to GitHub API requests."""
         headers ={
-            'Authorization': f'token {self.token()}',
+            'Authorization': f'token {self.token().token}',
             'Accept': 'application/vnd.github.machine-man-preview+json'}
+        return headers
 
 

--- a/py/code_intelligence/github_app.py
+++ b/py/code_intelligence/github_app.py
@@ -1,7 +1,10 @@
+import abc
 import logging
 import os
 
 from collections import namedtuple, Counter
+import datetime
+from dateutil import parser as date_parser
 from github3 import GitHub
 from pathlib import Path
 from cryptography.hazmat.backends import default_backend
@@ -17,6 +20,30 @@ class GitHubApp(GitHub):
     This is a small wrapper around the github3.py library
 
     Provides some convenience functions for testing purposes.
+
+    For reference on authenticating as a GitHub App see
+    https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-an-installation
+
+    Authenticating as a GitHub App works as follows
+
+    1. We use the PEM key and App Id for the application to generate a JWT
+    2. We us the JWT to make a request to the GitHub App to get the id
+       for the installation of that App on a particular repository
+       or organization
+    3. We use the JWT for the GitHub App and the installation id to get
+       an access token for the installation of the GitHub app on that
+       org or repo
+    4. We use the access token for that installation to perform actions on that
+       repository or org as that GitHub App
+
+
+    TODO(jlewi): This class should probably be refactored. We should
+    probably separate out helper functions for specific methods
+    (e.g. get_reactions) from utilities for authenticating as a GitHubApp
+
+    We should probably create a helper class just for generating access
+    tokens as a GitHub App. We should probably create a wrapper for tokens
+    that automatically refreshes tokens when needed.
     """
 
     def __init__(self, pem_path, app_id):
@@ -27,6 +54,10 @@ class GitHubApp(GitHub):
 
         if not self.path.is_file():
             raise ValueError(f'argument: `pem_path` must be a valid filename. {pem_path} was not found.')
+
+        # Create a cache for installation ids. The key
+        # is "{owner}/{repo}"
+        self._installation_ids = {}
 
     @staticmethod
     def create_from_env():
@@ -39,7 +70,7 @@ class GitHubApp(GitHub):
         with open(self.path, 'rb') as key_file:
             client = GitHub()
             client.login_as_app(private_key_pem=key_file.read(),
-                        app_id=self.app_id)
+                                app_id=self.app_id)
         return client
 
     def get_installation(self, installation_id):
@@ -90,20 +121,30 @@ class GitHubApp(GitHub):
 
     def get_installation_id(self, owner, repo):
         "https://developer.github.com/v3/apps/#find-repository-installation"
-        url = f'https://api.github.com/repos/{owner}/{repo}/installation'
+        key = f"{owner}/{repo}"
+        if key not in self._installation_ids:
+            logging.info(f"No installation id for {owner}/{repo} in cache")
+            url = f'https://api.github.com/repos/{owner}/{repo}/installation'
 
-        headers = {'Authorization': f'Bearer {self.get_jwt().decode()}',
-                   'Accept': 'application/vnd.github.machine-man-preview+json'}
+            headers = {'Authorization': f'Bearer {self.get_jwt().decode()}',
+                       'Accept': 'application/vnd.github.machine-man-preview+json'}
 
-        response = requests.get(url=url, headers=headers)
-        if response.status_code != 200:
-            raise Exception(f"There was a problem requesting URL={URL} "
-                            f"Status code : {response.status_code}, "
-                            f"Response:{response.json()}")
-        return response.json()['id']
+            response = requests.get(url=url, headers=headers)
+            if response.status_code != 200:
+                raise Exception(f"There was a problem requesting URL={URL} "
+                                f"Status code : {response.status_code}, "
+                                f"Response:{response.json()}")
+            self._installation_ids[key] = response.json()['id']
+
+        return self._installation_ids[key]
 
     def get_installation_access_token(self, installation_id):
-        "Get the installation access token."
+        """"Get the installation access token.
+
+        Args:
+          installation_id: The id for the install of the App on a particular
+            repository or og.
+        """
 
         url = f'https://api.github.com/app/installations/{installation_id}/access_tokens'
         headers = {'Authorization': f'Bearer {self.get_jwt().decode()}',
@@ -113,6 +154,19 @@ class GitHubApp(GitHub):
         if response.status_code != 201:
             raise Exception(f'Status code : {response.status_code}, {response.json()}')
         return response.json()['token']
+
+    def get_repo_access_token(self, repo):
+        """Get an access token for the specific repo.
+
+        Args:
+          repo: Id of the repo in format {owner}/{repo_name}
+        """
+
+        owner, name = repo.split("/")
+
+        installation_id = self.get_installation_id(owner, repo)
+
+        return self.get_installation_access_token(installation_id)
 
     def _extract(self, d, keys):
         "extract selected keys from a dict."
@@ -189,9 +243,125 @@ class GitHubApp(GitHub):
                                     body=issue.body,
                                     labels=[label.name for label in issue.labels()],
                                     url=issue.html_url)
-                             )
+                              )
         return issue_data
 
     def generate_installation_curl(self, endpoint):
         iat = self.get_installation_access_token()
         print(f'curl -i -H "Authorization: token {iat}" -H "Accept: application/vnd.github.machine-man-preview+json" https://api.github.com{endpoint}')
+
+
+# Tuple to represent a GitHub access token
+GITHUB_ACCESS_TOKEN = namedtuple("GitHubAccessToken", ("token", "expires_at"))
+
+class GitHubTokenGenerator(abc.ABC):
+    """A class for generating GitHub access tokens."""
+
+    @abc.abstractclassmethod
+    def token(self):
+        """Return an instance of GITHUB_ACCESS_TOKEN."""
+
+    @abc.abstractclassmethod
+    def auth_headers(self):
+        """Generate headers to attach to GitHub API requests."""
+
+class FixedAccessTokenGenerator(GitHubTokenGenerator):
+    """Represent a constant access token.
+
+    The primary use cases for this are personal access tokens.
+    """
+    def __init__(self):
+        self._token = None
+
+    @staticmethod
+    def from_env():
+        """Create the token from environment variables"""
+        # INPUT_ prefix is used when this is run inside the context of a
+        # GitHub Action
+        TRIAGE_TOKEN = os.getenv("INPUT_GITHUB_PERSONAL_ACCESS_TOKEN",
+                                 os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN"))
+        GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+
+        if not TRIAGE_TOKEN and not GITHUB_TOKEN :
+            raise ValueError("GITHUB_PERSONAL_ACCESS_TOKEN or GITHUB_TOKEN "
+                             "must be present as an environment variable upon "
+                             "instantiating this object.")
+
+        token = TRIAGE_TOKEN if TRIAGE_TOKEN else GITHUB_TOKEN
+
+        # Set an expiration time really far in the future to indicate the
+        # token never expires
+        forever = datetime.datetime.now() + datetime.timedelta(weeks=52*2)
+        self = FixedAccessTokenGenerator()
+        self._token = GITHUB_ACCESS_TOKEN(token, forever)
+        return self
+
+    def token(self):
+        return self._token
+
+    def auth_headers(self):
+        headers={'Authorization': f'token {self._token.token}',
+                 'Accept': 'application/vnd.github.machine-man-preview+json'}
+
+        return headers
+
+class GitHubAppTokenGenerator:
+    """A helper class for generating access tokens for installations.
+
+    To Authenticate to GitHub Apps as the installation of that app on some
+    repo we need to generate an access token.
+
+    This class handles generating and refreshing those tokens.
+
+    It provides convenience methods for generating the headers as well.
+    """
+
+    def __init__(self, app, repo,
+                 min_expire_time=datetime.timedelta(minutes=5)):
+        """Create a token generator.
+
+        Args:
+          app: Instance of GitHubApp
+          repo: Repo in the form of {owner}/{name} on which to generate tokens
+          min_expire_time: Minimum time until token expiration before we
+            refresh.
+        """
+
+        self._token = None
+        self._app = app
+        self._repo = repo
+        # Generate a fake expired token to force a refresh on first call
+        self._token = GITHUB_ACCESS_TOKEN("", datetime.datetime.now())
+
+    def token(self):
+        """Return the access token."""
+
+        now = datetime.datetime.now(tz=self._token.expires_at.tzinfo)
+        if now > self._token.expires_at:
+            logging.info(f"Refreshing access token")
+
+            owner, name = repo.split("/")
+
+            installation_id = self._app.get_installation_id(owner, repo)
+
+            url = f'https://api.github.com/app/installations/{installation_id}/access_tokens'
+            headers = {'Authorization': f'Bearer {self._app.get_jwt().decode()}',
+                       'Accept': 'application/vnd.github.machine-man-preview+json'}
+
+            response = requests.post(url=url, headers=headers)
+            if response.status_code != 201:
+                raise Exception(f'Status code : {response.status_code}, {response.json()}')
+
+            token = response.json()['token']
+            expires_at = date_parser.parse(token['expires_at'])
+            self._token = GITHUB_ACCESS_TOKEN(token, expires_at)
+
+        return self._token
+
+    def auth_headers(self):
+        """Generate headers to attach to GitHub API requests."""
+        headers ={
+            'Authorization': f'token {self.token()}',
+            'Accept': 'application/vnd.github.machine-man-preview+json'}
+
+

--- a/py/code_intelligence/github_app.py
+++ b/py/code_intelligence/github_app.py
@@ -104,10 +104,9 @@ class GitHubApp(GitHub):
         return next(test_repo.issues())
 
     def get_jwt(self):
-        """
-        This is needed to retrieve the installation access token (for debugging).
+        """This is needed to retrieve the installation access token.
 
-        Useful for debugging purposes.  Must call .decode() on returned object to get string.
+        Must call .decode() on returned object to get string.
         """
         now = self._now_int()
         payload = {
@@ -177,8 +176,6 @@ class GitHubApp(GitHub):
 
     def get_all_repos(self, installation_id):
         """Get all repos that this installation has access to.
-
-        Useful for testing and debugging.
         """
         url = 'https://api.github.com/installation/repositories'
         headers={'Authorization': f'token {self.get_installation_access_token(installation_id)}',

--- a/py/code_intelligence/graphql.py
+++ b/py/code_intelligence/graphql.py
@@ -24,7 +24,7 @@ class GraphQLClient(object):
       # INPUT_ prefix is used when this is run inside the context of a GitHub Action
       TRIAGE_TOKEN = os.getenv("INPUT_GITHUB_PERSONAL_ACCESS_TOKEN",
                                os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN"))
-      GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+      GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "").strip()
 
       if TRIAGE_TOKEN or GITHUB_TOKEN :
         logging.warning(f"GraphQLClient is defaulting to "
@@ -66,6 +66,7 @@ class GraphQLClient(object):
     if request.status_code == 200:
       return request.json()
     else:
+
       raise Exception("Query failed to run by returning code of {}. {}".format(
         request.status_code, query))
 

--- a/py/code_intelligence/graphql.py
+++ b/py/code_intelligence/graphql.py
@@ -1,39 +1,68 @@
 """This module contains utilities for working with GitHub's graphql API"""
+from code_intelligence import github_app
 from code_intelligence import util
 import logging
 import json
 import os
 import requests
+import traceback
 
 class GraphQLClient(object):
   """A graphql client for GitHub"""
 
-  def __init__(self):
-    # INPUT_ prefix is used when this is run inside the context of a GitHub Action
-    TRIAGE_TOKEN = os.getenv("INPUT_GITHUB_PERSONAL_ACCESS_TOKEN", os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN"))
-    GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+  def __init__(self, headers=None):
+    """Create a GraphQL Client
 
-    if not TRIAGE_TOKEN and not GITHUB_TOKEN :
-      raise ValueError("GITHUB_PERSONAL_ACCESS_TOKEN or GITHUB_TOKEN must be present as an environment variable upon instantiating this object.")
-    
-    token = TRIAGE_TOKEN if TRIAGE_TOKEN else GITHUB_TOKEN
-    self._headers = {"Authorization":
-                     "Bearer {0}".format(token)}
+    Args:
+      headers: (func () -> dict) Generate headers to be added to the
+       requests. This can be used to generate authorization tokens.
+       A commone use case is an instance of
+       FixedAccessTokenGenerator.auth_headers
+    """
+    if headers is None:
 
-  def run_query(self, query, variables=None):
+      # INPUT_ prefix is used when this is run inside the context of a GitHub Action
+      TRIAGE_TOKEN = os.getenv("INPUT_GITHUB_PERSONAL_ACCESS_TOKEN",
+                               os.getenv("GITHUB_PERSONAL_ACCESS_TOKEN"))
+      GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+
+      if TRIAGE_TOKEN or GITHUB_TOKEN :
+        logging.warning(f"GraphQLClient is defaulting to "
+                         "FixedAccessTokenGenerator based on environment "
+                         "variables. This is deprecated. Caller should "
+                         "explicitly pass in a instance via header_generator. "
+                         f"Traceback:\n{traceback.extract_stack}")
+
+
+        headers = github_app.FixedAccessTokenGenerator.from_env().auth_headers
+
+    self._headers = headers
+
+  def run_query(self, query, variables=None, headers=None):
     """Issue the GraphQL query and return the results.
 
     Args:
      query: String containing the query
      variables: Dictionary of variables
+     headers: (func () -> dict) Generate headers to be added to the
+       requests. This can be used to generate authorization tokens.
+       A commone use case is an instance of
+       FixedAccessTokenGenerator.auth_headers
     """
     payload = {'query': query}
 
     if variables:
       payload["variables"] = variables
 
+    header_values = {}
+    if self._headers:
+      header_values.update(self._headers())
+
+    if headers:
+      header_values.update(headers())
+
     request = requests.post('https://api.github.com/graphql',
-                            json=payload, headers=self._headers)
+                            json=payload, headers=header_values)
     if request.status_code == 200:
       return request.json()
     else:


### PR DESCRIPTION
* Create classes to make it easier to interchange the use of personal access
  tokens and GitHub app tokens.

* Create an abstract class to wrap a token that can be injected into client
  librabries like GraphQL

* Authenticating using GitHub App's has the following important differences
  compared to personal access tokens

  1. The tokens expire
  2. GitHub App tokens must be scoped to a specific repository or organization
     installation id

* We solve these problems as follows

  1. The GitHubAppTokenGenerator automatically refreshes credentials
  2. The GitHubAppTokenGenerator can be instantiated with the
     repository for which to get the installation id
  3. We add to GitHubApp caching of installation ids
  4. We modify GraphQL.run_query to take a function to generate the auth headers
     * We need to pass the token getter to run_query because each query
       could be for a different repository or organization and therefore
       require different credentials.

Related to #112
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/code-intelligence/113)
<!-- Reviewable:end -->
