### PR TITLE
Compute embeddings for all kubeflow repositories.

### DIFF
--- a/Issue_Embeddings/notebooks/01_AcquireData.ipynb
+++ b/Issue_Embeddings/notebooks/01_AcquireData.ipynb
@@ -155,9 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -501,8 +499,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/Issue_Embeddings/notebooks/02_fastai_DataBunch.ipynb
+++ b/Issue_Embeddings/notebooks/02_fastai_DataBunch.ipynb
@@ -267,9 +267,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/Issue_Embeddings/notebooks/03_Create_Model.ipynb
+++ b/Issue_Embeddings/notebooks/03_Create_Model.ipynb
@@ -282,9 +282,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/Issue_Embeddings/notebooks/07_Get_Repo_TrainingData_BigQuery.ipynb
+++ b/Issue_Embeddings/notebooks/07_Get_Repo_TrainingData_BigQuery.ipynb
@@ -451,9 +451,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/Issue_Embeddings/notebooks/Get-GitHub-Issues.ipynb
+++ b/Issue_Embeddings/notebooks/Get-GitHub-Issues.ipynb
@@ -4,11 +4,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Running this Notebook\n",
+    "# Fetch GitHub Issues and Compute Embeddings\n",
     "\n",
-    "This notebook is run in the container: [hamelsmu/ml-gpu-issue-lang-model](https://github.com/machine-learning-apps/IssuesLanguageModel/blob/master/gpu.Dockerfile)\n",
+    "* This notebook downloads GitHub Issues and then computes the embeddings using a trained model\n",
+    "* [issues_loader.ipynb](../Label_Microservice/notebooks/issues_loader.ipynb) is a very similar notebook\n",
     "\n",
-    "This container is publicly available [on Dockerhub](https://cloud.docker.com/u/hamelsmu/repository/docker/hamelsmu/ml-gpu-issue-lang-model)\n",
+    "   * That notebook however just uses the IssuesLoader class as way of hard coding some paths."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running this Notebook\n",
+    "\n",
+    "* This notebook was last run on [gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0]\n",
+    "* Resource specs\n",
+    "  * **CPU** 15\n",
+    "  * **RAM** 32Gi\n",
+    "  \n",
+    "* If kernel dies while computing embeddings it could be because you run out of memory\n",
     "\n",
     "#### Compute: This notebook was run on a [p3.8xlarge](https://aws.amazon.com/ec2/instance-types/p3/) on AWS\n",
     "Tesla V100 GPU, 32 vCPUs 244GB of Memory"
@@ -18,48 +33,183 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Adding /home/jovyan/git_kubeflow-code-intelligence/py to python path\n"
+     ]
+    }
+   ],
    "source": [
-    "from bs4 import BeautifulSoup\n",
-    "import requests\n",
-    "from fastai.core import parallel, partial\n",
-    "from collections import Counter\n",
-    "from tqdm import tqdm_notebook\n",
-    "import torch"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Write Functions To Get Data"
+    "import logging\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "import sys\n",
+    "\n",
+    "logging.basicConfig(format='%(message)s')\n",
+    "logging.getLogger().setLevel(logging.INFO)\n",
+    "\n",
+    "home = str(Path.home())\n",
+    "\n",
+    "# Installing the python packages locally doesn't appear to have them automatically\n",
+    "# added the path so we need to manually add the directory\n",
+    "local_py_path = os.path.join(home, \".local/lib/python3.6/site-packages\")\n",
+    "\n",
+    "for p in [local_py_path, os.path.abspath(\"../../py\")]:\n",
+    "    if p not in sys.path:\n",
+    "      logging.info(\"Adding %s to python path\", p)\n",
+    "      # Insert at front because we want to override any installed packages\n",
+    "      sys.path.insert(0, p)\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already up-to-date: appnope==0.1.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 2)) (0.1.0)\n",
+      "Requirement already up-to-date: attrs==19.1.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 3)) (19.1.0)\n",
+      "Requirement already up-to-date: backcall==0.1.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 4)) (0.1.0)\n",
+      "Requirement already up-to-date: beautifulsoup4==4.7.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 5)) (4.7.1)\n",
+      "Requirement already up-to-date: bleach==3.1.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 6)) (3.1.0)\n",
+      "Requirement already up-to-date: blis==0.2.4 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 7)) (0.2.4)\n",
+      "Requirement already up-to-date: bottleneck==1.2.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 8)) (1.2.1)\n",
+      "Requirement already up-to-date: bs4==0.0.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 9)) (0.0.1)\n",
+      "Requirement already up-to-date: cachetools==3.1.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 10)) (3.1.1)\n",
+      "Requirement already up-to-date: certifi==2019.3.9 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 11)) (2019.3.9)\n",
+      "Requirement already up-to-date: cffi==1.12.3 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 12)) (1.12.3)\n",
+      "Requirement already up-to-date: chardet==3.0.4 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 13)) (3.0.4)\n",
+      "Requirement already up-to-date: click==7.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 14)) (7.0)\n",
+      "Requirement already up-to-date: cycler==0.10.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 15)) (0.10.0)\n",
+      "Requirement already up-to-date: cymem==2.0.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 16)) (2.0.2)\n",
+      "Requirement already up-to-date: cytoolz==0.9.0.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 17)) (0.9.0.1)\n",
+      "Requirement already up-to-date: decorator==4.4.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 18)) (4.4.0)\n",
+      "Requirement already up-to-date: defusedxml==0.6.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 19)) (0.6.0)\n",
+      "Requirement already up-to-date: dill==0.3.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 20)) (0.3.0)\n",
+      "Requirement already up-to-date: entrypoints==0.3 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 21)) (0.3)\n",
+      "Requirement already up-to-date: fastai==1.0.53.post3 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 22)) (1.0.53.post3)\n",
+      "Requirement already up-to-date: fastprogress==0.1.21 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 23)) (0.1.21)\n",
+      "Requirement already up-to-date: flask-session==0.3.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 24)) (0.3.1)\n",
+      "Requirement already up-to-date: flask==1.0.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 25)) (1.0.2)\n",
+      "Requirement already up-to-date: ftfy==4.4.3 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 26)) (4.4.3)\n",
+      "Requirement already up-to-date: gcsfs==0.2.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 27)) (0.2.1)\n",
+      "Requirement already up-to-date: github3.py>=1.3.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 28)) (1.3.0)\n",
+      "Requirement already up-to-date: google-auth-oauthlib in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 29)) (0.4.1)\n",
+      "Requirement already up-to-date: google-auth in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 30)) (1.13.1)\n",
+      "Requirement already up-to-date: google-cloud-bigquery in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 31)) (1.24.0)\n",
+      "Requirement already up-to-date: gunicorn==19.9.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 32)) (19.9.0)\n",
+      "Requirement already up-to-date: html5lib==1.0.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 33)) (1.0.1)\n",
+      "Requirement already up-to-date: idna==2.8 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 34)) (2.8)\n",
+      "Requirement already up-to-date: ijson==2.3 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 35)) (2.3)\n",
+      "Requirement already up-to-date: ipdb==0.12 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 36)) (0.12)\n",
+      "Requirement already up-to-date: ipykernel==5.1.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 37)) (5.1.0)\n",
+      "Requirement already up-to-date: ipython-genutils==0.2.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 38)) (0.2.0)\n",
+      "Requirement already up-to-date: ipython==7.5.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 39)) (7.5.0)\n",
+      "Requirement already up-to-date: ipywidgets==7.4.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 40)) (7.4.2)\n",
+      "Requirement already up-to-date: itsdangerous==1.1.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 41)) (1.1.0)\n",
+      "Requirement already up-to-date: jedi==0.13.3 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 42)) (0.13.3)\n",
+      "Requirement already up-to-date: jinja2==2.10.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 43)) (2.10.1)\n",
+      "Requirement already up-to-date: joblib==0.13.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 44)) (0.13.2)\n",
+      "Requirement already up-to-date: jsonschema==3.0.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 45)) (3.0.1)\n",
+      "Requirement already up-to-date: JSON-log-formatter==0.2.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 46)) (0.2.0)\n",
+      "Requirement already up-to-date: jupyter-client==5.2.4 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 47)) (5.2.4)\n",
+      "Requirement already up-to-date: jupyter-core==4.4.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 48)) (4.4.0)\n",
+      "Requirement already up-to-date: kiwisolver==1.1.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 49)) (1.1.0)\n",
+      "Requirement already up-to-date: markupsafe==1.1.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 50)) (1.1.1)\n",
+      "Requirement already up-to-date: matplotlib==3.0.3 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 51)) (3.0.3)\n",
+      "Requirement already up-to-date: mdparse==0.13 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 52)) (0.13)\n",
+      "Requirement already up-to-date: mistune==0.8.4 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 53)) (0.8.4)\n",
+      "Requirement already up-to-date: more-itertools==8.2.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 54)) (8.2.0)\n",
+      "Requirement already up-to-date: murmurhash==1.0.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 55)) (1.0.2)\n",
+      "Requirement already up-to-date: mwparserfromhell==0.5.3 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 56)) (0.5.3)\n",
+      "Requirement already up-to-date: nbconvert==5.5.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 57)) (5.5.0)\n",
+      "Requirement already up-to-date: nbformat==4.4.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 58)) (4.4.0)\n",
+      "Requirement already up-to-date: networkx==2.3 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 59)) (2.3)\n",
+      "Requirement already up-to-date: notebook==5.7.8 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 60)) (5.7.8)\n",
+      "Requirement already up-to-date: numexpr==2.6.9 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 61)) (2.6.9)\n",
+      "Requirement already up-to-date: numpy==1.16.4 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 62)) (1.16.4)\n",
+      "Requirement already up-to-date: oauthlib==3.0.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 63)) (3.0.1)\n",
+      "Requirement already up-to-date: packaging==19.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 64)) (19.0)\n",
+      "Requirement already up-to-date: pandas==0.24.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 65)) (0.24.2)\n",
+      "Requirement already up-to-date: pandas-gbq in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 66)) (0.13.1)\n",
+      "Requirement already up-to-date: pandocfilters==1.4.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 67)) (1.4.2)\n",
+      "Requirement already up-to-date: parso==0.4.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 68)) (0.4.0)\n",
+      "Requirement already up-to-date: passlib==1.7.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 69)) (1.7.1)\n",
+      "Requirement already up-to-date: pexpect==4.7.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 70)) (4.7.0)\n",
+      "Requirement already up-to-date: pickleshare==0.7.5 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 71)) (0.7.5)\n",
+      "Requirement already up-to-date: pillow==6.0.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 72)) (6.0.0)\n",
+      "Requirement already up-to-date: plac==0.9.6 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 73)) (0.9.6)\n",
+      "Requirement already up-to-date: preshed==2.0.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 74)) (2.0.1)\n",
+      "Requirement already up-to-date: prometheus-client==0.6.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 75)) (0.6.0)\n",
+      "Requirement already up-to-date: prompt-toolkit==2.0.9 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 76)) (2.0.9)\n",
+      "Requirement already up-to-date: ptyprocess==0.6.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 77)) (0.6.0)\n",
+      "Requirement already up-to-date: pyasn1-modules==0.2.5 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 78)) (0.2.5)\n",
+      "Requirement already up-to-date: pyasn1==0.4.5 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 79)) (0.4.5)\n",
+      "Requirement already up-to-date: pycparser==2.19 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 80)) (2.19)\n",
+      "Requirement already up-to-date: pyemd==0.5.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 81)) (0.5.1)\n",
+      "Requirement already up-to-date: pygments==2.4.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 82)) (2.4.2)\n",
+      "Requirement already up-to-date: pyparsing==2.4.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 83)) (2.4.0)\n",
+      "Requirement already up-to-date: pyphen==0.9.5 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 84)) (0.9.5)\n",
+      "Requirement already up-to-date: pyrsistent==0.15.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 85)) (0.15.2)\n",
+      "Requirement already up-to-date: python-dateutil==2.8.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 86)) (2.8.0)\n",
+      "Requirement already up-to-date: python-levenshtein==0.12.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 87)) (0.12.0)\n",
+      "Requirement already up-to-date: pytz==2019.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 88)) (2019.1)\n",
+      "Requirement already up-to-date: pyyaml==5.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 89)) (5.1)\n",
+      "Requirement already up-to-date: pyzmq==18.0.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 90)) (18.0.1)\n",
+      "Requirement already up-to-date: regex==2019.6.8 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 91)) (2019.6.8)\n",
+      "Requirement already up-to-date: requests-oauthlib==1.2.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 92)) (1.2.0)\n",
+      "Requirement already up-to-date: requests==2.22.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 93)) (2.22.0)\n",
+      "Requirement already up-to-date: rsa==4.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 94)) (4.0)\n",
+      "Requirement already up-to-date: scikit-learn==0.20.3 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 95)) (0.20.3)\n",
+      "Requirement already up-to-date: scipy==1.2.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 96)) (1.2.1)\n",
+      "Requirement already up-to-date: send2trash==1.5.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 97)) (1.5.0)\n",
+      "Requirement already up-to-date: six>=1.13.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 98)) (1.14.0)\n",
+      "Requirement already up-to-date: soupsieve==1.9.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 99)) (1.9.1)\n",
+      "Requirement already up-to-date: spacy==2.1.4 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 100)) (2.1.4)\n",
+      "Requirement already up-to-date: srsly==0.0.7 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 101)) (0.0.7)\n",
+      "Requirement already up-to-date: terminado==0.8.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 102)) (0.8.2)\n",
+      "Requirement already up-to-date: testpath==0.4.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 103)) (0.4.2)\n",
+      "Requirement already up-to-date: textacy==0.7.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 104)) (0.7.1)\n",
+      "Requirement already up-to-date: thinc==7.0.4 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 105)) (7.0.4)\n",
+      "Requirement already up-to-date: timeout-decorator==0.4.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 106)) (0.4.1)\n",
+      "Requirement already up-to-date: toolz==0.9.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 107)) (0.9.0)\n",
+      "Requirement already up-to-date: tornado==6.0.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 108)) (6.0.2)\n",
+      "Requirement already up-to-date: torch==1.1.0 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 109)) (1.1.0)\n",
+      "Requirement already up-to-date: tqdm==4.32.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 110)) (4.32.2)\n",
+      "Requirement already up-to-date: traitlets==4.3.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 111)) (4.3.2)\n",
+      "Requirement already up-to-date: typing==3.6.6 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 112)) (3.6.6)\n",
+      "Requirement already up-to-date: urllib3==1.24.3 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 113)) (1.24.3)\n",
+      "Requirement already up-to-date: wasabi==0.2.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 114)) (0.2.2)\n",
+      "Requirement already up-to-date: wcwidth==0.1.7 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 115)) (0.1.7)\n",
+      "Requirement already up-to-date: webencodings==0.5.1 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 116)) (0.5.1)\n",
+      "Requirement already up-to-date: werkzeug==0.15.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 117)) (0.15.2)\n",
+      "Requirement already up-to-date: widgetsnbextension==3.4.2 in /home/jovyan/.local/lib/python3.6/site-packages (from -r ../requirements.txt (line 118)) (3.4.2)\n",
+      "Requirement already satisfied, skipping upgrade: torchvision in /home/jovyan/.local/lib/python3.6/site-packages (from fastai==1.0.53.post3->-r ../requirements.txt (line 22)) (0.5.0)\n",
+      "Requirement already satisfied, skipping upgrade: nvidia-ml-py3 in /home/jovyan/.local/lib/python3.6/site-packages (from fastai==1.0.53.post3->-r ../requirements.txt (line 22)) (7.352.0)\n",
+      "Requirement already satisfied, skipping upgrade: dataclasses; python_version < \"3.7\" in /home/jovyan/.local/lib/python3.6/site-packages (from fastai==1.0.53.post3->-r ../requirements.txt (line 22)) (0.7)\n",
+      "Requirement already satisfied, skipping upgrade: uritemplate>=3.0.0 in /home/jovyan/.local/lib/python3.6/site-packages (from github3.py>=1.3.0->-r ../requirements.txt (line 28)) (3.0.1)\n",
+      "Requirement already satisfied, skipping upgrade: jwcrypto>=0.5.0 in /home/jovyan/.local/lib/python3.6/site-packages (from github3.py>=1.3.0->-r ../requirements.txt (line 28)) (0.7)\n",
+      "Requirement already satisfied, skipping upgrade: setuptools>=40.3.0 in /home/jovyan/.local/lib/python3.6/site-packages (from google-auth->-r ../requirements.txt (line 30)) (46.1.3)\n",
+      "Requirement already satisfied, skipping upgrade: protobuf>=3.6.0 in /home/jovyan/.local/lib/python3.6/site-packages (from google-cloud-bigquery->-r ../requirements.txt (line 31)) (3.11.3)\n",
+      "Requirement already satisfied, skipping upgrade: google-resumable-media<0.6dev,>=0.5.0 in /home/jovyan/.local/lib/python3.6/site-packages (from google-cloud-bigquery->-r ../requirements.txt (line 31)) (0.5.0)\n",
+      "Requirement already satisfied, skipping upgrade: google-cloud-core<2.0dev,>=1.1.0 in /home/jovyan/.local/lib/python3.6/site-packages (from google-cloud-bigquery->-r ../requirements.txt (line 31)) (1.3.0)\n",
+      "Requirement already satisfied, skipping upgrade: google-api-core<2.0dev,>=1.15.0 in /home/jovyan/.local/lib/python3.6/site-packages (from google-cloud-bigquery->-r ../requirements.txt (line 31)) (1.16.0)\n",
+      "Requirement already satisfied, skipping upgrade: pydata-google-auth in /home/jovyan/.local/lib/python3.6/site-packages (from pandas-gbq->-r ../requirements.txt (line 66)) (0.3.0)\n",
+      "Requirement already satisfied, skipping upgrade: cryptography>=1.5 in /home/jovyan/.local/lib/python3.6/site-packages (from jwcrypto>=0.5.0->github3.py>=1.3.0->-r ../requirements.txt (line 28)) (2.9)\n",
+      "Requirement already satisfied, skipping upgrade: googleapis-common-protos<2.0dev,>=1.6.0 in /home/jovyan/.local/lib/python3.6/site-packages (from google-api-core<2.0dev,>=1.15.0->google-cloud-bigquery->-r ../requirements.txt (line 31)) (1.51.0)\n",
+      "\u001b[33mWARNING: You are using pip version 19.3.1; however, version 20.0.2 is available.\n",
+      "You should consider upgrading via the 'pip install --upgrade pip' command.\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
-    "def find_max_issue_num(owner, repo):\n",
-    "    \"\"\"\n",
-    "    Find the maximum issue number associated with a repo.\n",
-    "    \n",
-    "    Returns\n",
-    "    -------\n",
-    "    int\n",
-    "        the highest issue number associated with this repo.\n",
-    "    \"\"\"\n",
-    "    url = f'https://github.com/{owner}/{repo}/issues'\n",
-    "    r = requests.get(url)\n",
-    "    if not r.ok:\n",
-    "        r.raise_for_status()\n",
-    "    soup = BeautifulSoup(r.content)\n",
-    "    # get grey text under issue preview cards\n",
-    "    issue_meta = soup.find('span', class_=\"opened-by\").text\n",
-    "    # parse the first issue number visible, which is also the highest issue number\n",
-    "    issue_num = issue_meta.strip().split('\\n')[0][1:]\n",
-    "    return int(issue_num)"
+    "!pip3 install --user --upgrade -r ../requirements.txt"
    ]
   },
   {
@@ -68,116 +218,82 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def verify_issue(owner, repo, num):\n",
-    "    \"\"\"\n",
-    "    Verify that owner/repo/issues/num exists.  \n",
-    "    \n",
-    "    Returns\n",
-    "    -------\n",
-    "    bool\n",
-    "        True/False if issue exists.\n",
-    "    \n",
-    "    Note that pull requests are also issues but will \n",
-    "    get redirected with a status code 302, allowing\n",
-    "    this function to return False.\n",
-    "    \"\"\"\n",
-    "    \n",
-    "    url = f'https://github.com/{owner}/{repo}/issues/{num}'\n",
-    "    \n",
-    "    if requests.head(url).status_code != 200:\n",
-    "        return False\n",
-    "    else:\n",
-    "        return True"
+    "from bs4 import BeautifulSoup\n",
+    "import requests\n",
+    "from fastai.core import parallel, partial\n",
+    "\n",
+    "from collections import Counter\n",
+    "from tqdm import tqdm_notebook\n",
+    "import torch\n",
+    "from code_intelligence import embeddings\n",
+    "from code_intelligence import graphql\n",
+    "from code_intelligence import gcs_util\n",
+    "from google.cloud import storage"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get a list of Kubeflow REPOs\n",
+    "\n",
+    "* You will need to either set a GitHub token or use a GitHub App in order to call the API\n",
+    "* TODO(jlewi): This is no longer really necessary since we are using BigQuery now to fetch the data we can query by org"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 194,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "GraphQLClient is defaulting to FixedAccessTokenGenerator based on environment variables. This is deprecated. Caller should explicitly pass in a instance via header_generator. Traceback:\n",
+      "<function extract_stack at 0x7f31376bd6a8>\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['arena', 'batch-predict', 'caffe2-operator', 'chainer-operator', 'code-intelligence', 'common', 'community', 'crd-validation', 'example-seldon', 'examples', 'fairing', 'features', 'frontend', 'homebrew-cask', 'homebrew-core', 'internal-acls', 'katib', 'kfctl', 'kfp-tekton', 'kfserving', 'kubebench', 'kubeflow', 'manifests', 'marketing-materials', 'metadata', 'mpi-operator', 'mxnet-operator', 'pipelines', 'pytorch-operator', 'reporting', 'testing', 'tf-operator', 'triage-issues', 'website', 'xgboost-operator']\n"
+     ]
+    }
+   ],
    "source": [
-    "def get_issue_text(num, idx, owner, repo, skip_issue=True):\n",
-    "    \"\"\"\n",
-    "    Get the raw text of an issue body and label.\n",
+    "if not os.getenv(\"GITHUB_TOKEN\"):\n",
+    "    logging.warning(f\"No GitHub token set defaulting to hardcode list of Kubeflow repositories\")\n",
     "    \n",
-    "    Returns\n",
-    "    ------\n",
-    "    dict\n",
-    "        {'title':str, 'body':str}\n",
-    "    \"\"\"\n",
-    "    url = f'https://github.com/{owner}/{repo}/issues/{num}'\n",
-    "    if not verify_issue(owner, repo, num):\n",
-    "        if skip_issue:\n",
-    "            return None\n",
-    "        raise Exception(f'{url} is not an issue.')\n",
+    "    # The list of repos can be updated using the else block\n",
+    "    repo_names = ['arena', 'batch-predict', 'caffe2-operator', 'chainer-operator', 'code-intelligence', 'common', 'community', 'crd-validation', 'example-seldon', 'examples', 'fairing', 'features', 'frontend', 'homebrew-cask', 'homebrew-core', 'internal-acls', 'katib', 'kfctl', 'kfp-tekton', 'kfserving', 'kubebench', 'kubeflow', 'manifests', 'marketing-materials', 'metadata', 'mpi-operator', 'mxnet-operator', 'pipelines', 'pytorch-operator', 'reporting', 'testing', 'tf-operator', 'triage-issues', 'website', 'xgboost-operator']\n",
+    "else:\n",
+    "    gh_client = graphql.GraphQLClient()\n",
     "        \n",
-    "    soup = BeautifulSoup(requests.get(url).content)\n",
-    "    title_find = soup.find(\"span\", class_=\"js-issue-title\")\n",
-    "    body_find = soup.find(\"td\", class_=\"js-comment-body\")\n",
-    "    label_find = soup.find(class_='js-issue-labels')\n",
-    "    \n",
-    "    if not title_find or not body_find:\n",
-    "        return None\n",
-    "    \n",
-    "    title = title_find.get_text().strip()\n",
-    "    body = body_find.get_text().strip()\n",
-    "    labels = label_find.get_text().strip().split('\\n')\n",
-    "    \n",
-    "    if labels[0] == 'None yet':\n",
-    "        return None\n",
-    "    \n",
-    "    return {'title':title,\n",
-    "            'url':url,\n",
-    "            'body': body,\n",
-    "            'labels': labels}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 67,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def get_all_issue_text(owner, repo, inf_wrapper, workers=64, min_freq=25):\n",
-    "    c = Counter()\n",
-    "    # prepare list of issue nums\n",
-    "    owner=owner\n",
-    "    repo=repo\n",
-    "    max_num = find_max_issue_num(owner, repo)\n",
-    "    \n",
-    "    get = partial(get_issue_text, owner=owner, repo=repo, skip_issue=True)\n",
-    "    issues = parallel(get, list(range(1, max_num+1)), max_workers=workers)\n",
-    "    # filter out issues with problems\n",
-    "    filtered_issues = []\n",
-    "    \n",
-    "    for issue in issues:\n",
-    "        if issue:\n",
-    "            c.update(issue['labels'])\n",
-    "            filtered_issues.append(issue)\n",
-    "    \n",
-    "    frequent_issues = [x for x in c if c[x] >= min_freq]\n",
-    "    \n",
-    "    print(f'Retrieved {len(filtered_issues)} issues.')\n",
-    "    \n",
-    "    # only retain top n issues\n",
-    "    features = []\n",
-    "    labels = []\n",
-    "    for issue in tqdm_notebook(filtered_issues):\n",
-    "        lbls = [i for i in issue['labels'] if i in frequent_issues]\n",
-    "        if lbls:\n",
-    "            labels.append(lbls)\n",
-    "            # calculate embedding\n",
-    "            text = inf_wrapper.process_dict(issue)['text']\n",
-    "            feature = inf_wrapper.get_pooled_features(text).detach().cpu()\n",
-    "            # only need the first 1600 dimensions\n",
-    "            features.append(feature[:, :1600])\n",
-    "            \n",
-    "    print(f'{len(features)} issues remaining after minimum frequency filter of {min_freq}.')\n",
-    "    \n",
-    "    assert len(features) == len(labels), 'Error you have mismatch b/w number of observations and labels.'\n",
-    "    \n",
-    "    return {'features':torch.cat(features).numpy(), \n",
-    "            'labels': labels}"
+    "    repo_query=\"\"\"query repoQuery($org: String!) {\n",
+    "       organization(login: $org) {\n",
+    "        repositories(first:100) {\n",
+    "          totalCount \n",
+    "          edges {\n",
+    "            node {\n",
+    "              name\n",
+    "            }\n",
+    "          }\n",
+    "        }\n",
+    "      }\n",
+    "    }\n",
+    "    \"\"\"\n",
+    "    variables = {\n",
+    "        \"org\": \"kubeflow\",\n",
+    "    }\n",
+    "    results = gh_client.run_query(repo_query, variables)\n",
+    "    repo_nodes = graphql.unpack_and_split_nodes(results, [\"data\", \"organization\", \"repositories\", \"edges\"])\n",
+    "    repo_names = [n[\"name\"] for n in repo_nodes]\n",
+    "\n",
+    "    \",\".join([f\"'{n}'\" for n in sorted(repo_names)])\n",
+    "    names_str = \", \".join([f\"'{n}'\" for n in sorted(repo_names)])\n",
+    "    print(f\"[{names_str}]\")"
    ]
   },
   {
@@ -189,21 +305,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2\n",
     "import pandas as pd\n",
     "from inference import InferenceWrapper"
    ]
@@ -212,12 +317,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Load Model Artifacts (Download from GC if not on local)"
+    "## Load Model Artifacts (Download from GC if not on local)\n",
+    "\n",
+    "* We need to load the model used to compute embeddings"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,103 +335,710 @@
     "    return x\n",
     "\n",
     "model_url = 'https://storage.googleapis.com/issue_label_bot/model/lang_model/models_22zkdqlr/trained_model_22zkdqlr.pkl'\n",
-    "path = Path('./model_files')\n",
-    "full_path = path/'model.pkl'\n",
-    "\n",
-    "if not full_path.exists():\n",
-    "    print('Loading model.')\n",
-    "    path.mkdir(exist_ok=True)\n",
-    "    request_url.urlretrieve(model_url, path/'model.pkl') \n",
-    "inference_wrapper = InferenceWrapper(model_path=path, model_file_name='model.pkl')"
+    "inference_wrapper = embeddings.load_model_artifact(model_url)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Warning: The below cell benefits tremendously from parallelism, the more cores your machine has the better"
+    "#### Warning: The below cell benefits tremendously from parallelism, the more cores your machine has the better\n",
+    "\n",
+    "* The code will fail if you aren't running with a GPU"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get the Data Using BigQuery\n",
+    "\n",
+    "* We can use BigQuery to fetch the data from the GitHub Archive\n",
+    "* Here is a list of [GitHub Event Types](https://developer.github.com/v3/activity/events/types/)\n",
+    "  * We need to consider both [IssuesEvent](https://developer.github.com/v3/activity/events/types/#issuesevent) and [IssueCommentEvent](https://developer.github.com/v3/activity/events/types/#issuecommentevent)\n",
+    "* At the time of this writing 2020/04/08 there are approximately 137K events in Kubeflow and it takes O(30) seconds to fetch all of them.\n",
+    "* TODO\n",
+    "  * It looks like when we transfer a repo or maybe an issue we end up with duplicate entries with diffferent URLs (original and new one). We should look into dedupping those"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pandas.io import gbq\n",
+    "import subprocess \n",
+    "# TODO(jlewi): Get the project using fairing?\n",
+    "PROJECT = subprocess.check_output([\"gcloud\", \"config\", \"get-value\", \"project\"]).strip().decode()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 166,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  Elapsed 6.5 s. Waiting...\n",
+      "  Elapsed 7.64 s. Waiting...\n",
+      "  Elapsed 8.77 s. Waiting...\n",
+      "  Elapsed 9.89 s. Waiting...\n",
+      "  Elapsed 11.01 s. Waiting...\n",
+      "  Elapsed 12.13 s. Waiting...\n",
+      "  Elapsed 13.25 s. Waiting...\n",
+      "  Elapsed 14.36 s. Waiting...\n",
+      "Downloading: 100%|██████████| 138044/138044 [00:33<00:00, 2964.10rows/s]\n",
+      "Total time taken 49.03 s.\n",
+      "Finished at 2020-04-11 22:04:11.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"\"\"SELECT          \n",
+    "          JSON_EXTRACT(payload, '$.issue.html_url') as html_url,\n",
+    "          JSON_EXTRACT(payload, '$.issue.title') as title,\n",
+    "          JSON_EXTRACT(payload, '$.issue.body') as body,\n",
+    "          JSON_EXTRACT(payload, \"$.issue.labels\") as labels,\n",
+    "          JSON_EXTRACT(payload, \"$.issue.updated_at\") as updated_at,\n",
+    "          org.login,\n",
+    "          type,\n",
+    "      FROM `githubarchive.month.20*`\n",
+    "      WHERE  (type=\"IssuesEvent\" or type=\"IssueCommentEvent\") and org.login = 'kubeflow'\"\"\"\n",
+    "issues_and_pulls=gbq.read_gbq(query, dialect='standard', project_id=PROJECT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Pull request comments also get included so we need to filter those out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "pattern = re.compile(\".*issues/[\\d]+\")\n",
+    "issues_index = issues_and_pulls[\"html_url\"].apply(lambda x: pattern.match(x) is not None)\n",
+    "issues=issues_and_pulls[issues_index]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* We need to group the events by issue and then select the most recent event for each issue as that should have\n",
+    "  the most up to date labels for each issue\n",
+    "* TODO(jlewi): We should look for the most recent event in the dataset and then have some alert if the age exceeds some\n",
+    "  limit as that indicates the data isn't up to date."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "latest_issues = issues.groupby(\"html_url\", as_index=False).apply(lambda x: x.sort_values([\"updated_at\"]).iloc[-1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>html_url</th>\n",
+       "      <th>title</th>\n",
+       "      <th>body</th>\n",
+       "      <th>labels</th>\n",
+       "      <th>updated_at</th>\n",
+       "      <th>login</th>\n",
+       "      <th>type</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>4310</th>\n",
+       "      <td>\"https://github.com/kubeflow/kubeflow/issues/4...</td>\n",
+       "      <td>\"Open Data Hub &amp; Kubeflow relationship\"</td>\n",
+       "      <td>\"/kind question\\r\\n\\r\\nHi all,\\r\\n\\r\\nAs some ...</td>\n",
+       "      <td>[{\"id\":1182962369,\"node_id\":\"MDU6TGFiZWwxMTgyO...</td>\n",
+       "      <td>\"2020-04-08T23:06:36Z\"</td>\n",
+       "      <td>kubeflow</td>\n",
+       "      <td>IssueCommentEvent</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               html_url  \\\n",
+       "4310  \"https://github.com/kubeflow/kubeflow/issues/4...   \n",
+       "\n",
+       "                                        title  \\\n",
+       "4310  \"Open Data Hub & Kubeflow relationship\"   \n",
+       "\n",
+       "                                                   body  \\\n",
+       "4310  \"/kind question\\r\\n\\r\\nHi all,\\r\\n\\r\\nAs some ...   \n",
+       "\n",
+       "                                                 labels  \\\n",
+       "4310  [{\"id\":1182962369,\"node_id\":\"MDU6TGFiZWwxMTgyO...   \n",
+       "\n",
+       "                  updated_at     login               type  \n",
+       "4310  \"2020-04-08T23:06:36Z\"  kubeflow  IssueCommentEvent  "
+      ]
+     },
+     "execution_count": 169,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Example of fetching a specific issue\n",
+    "# This allows easy spot checking of the data\n",
+    "some_issue = \"https://github.com/kubeflow/kubeflow/issues/4916\"\n",
+    "test_issue = latest_issues.loc[latest_issues[\"html_url\"]==f'\"{some_issue}\"']\n",
+    "test_issue"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* We need to parse the labels which are json and get the names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 170,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "def get_labels(x):\n",
+    "    d = json.loads(x)\n",
+    "    return [i[\"name\"] for i in d]\n",
+    "\n",
+    "latest_issues[\"parsed_labels\"] = latest_issues[\"labels\"].apply(get_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* We need to deserialize the json strings to remove escaping"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 171,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for f in [\"html_url\", \"title\", \"body\"]:\n",
+    "    latest_issues[f] = latest_issues[f].apply(lambda x : json.loads(x))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute Embeddings\n",
+    "\n",
+    "* For each repo compute the embeddings and save to GCS\n",
+    "* TODO(jlewi): Can we use the metadata storage to keep track of artifacts?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 230,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_data = latest_issues[[\"title\", \"body\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 231,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Model inference: 0 / 7848\n",
+      "Model inference: 100 / 7848\n",
+      "Model inference: 200 / 7848\n",
+      "Model inference: 300 / 7848\n",
+      "Model inference: 400 / 7848\n",
+      "Model inference: 500 / 7848\n",
+      "Model inference: 600 / 7848\n",
+      "Model inference: 700 / 7848\n",
+      "Model inference: 800 / 7848\n",
+      "Model inference: 900 / 7848\n",
+      "Model inference: 1000 / 7848\n",
+      "Model inference: 1100 / 7848\n",
+      "Model inference: 1200 / 7848\n",
+      "Model inference: 1300 / 7848\n",
+      "Model inference: 1400 / 7848\n",
+      "Model inference: 1500 / 7848\n",
+      "Model inference: 1600 / 7848\n",
+      "Model inference: 1700 / 7848\n",
+      "Model inference: 1800 / 7848\n",
+      "Model inference: 1900 / 7848\n",
+      "Model inference: 2000 / 7848\n",
+      "Model inference: 2100 / 7848\n",
+      "Model inference: 2200 / 7848\n",
+      "Model inference: 2300 / 7848\n",
+      "Model inference: 2400 / 7848\n",
+      "Model inference: 2500 / 7848\n",
+      "Model inference: 2600 / 7848\n",
+      "Model inference: 2700 / 7848\n",
+      "Model inference: 2800 / 7848\n",
+      "Model inference: 2900 / 7848\n",
+      "Model inference: 3000 / 7848\n",
+      "Model inference: 3100 / 7848\n",
+      "Model inference: 3200 / 7848\n",
+      "Model inference: 3300 / 7848\n",
+      "Model inference: 3400 / 7848\n",
+      "Model inference: 3500 / 7848\n",
+      "Model inference: 3600 / 7848\n",
+      "Model inference: 3700 / 7848\n",
+      "Model inference: 3800 / 7848\n",
+      "Model inference: 3900 / 7848\n",
+      "Model inference: 4000 / 7848\n",
+      "Model inference: 4100 / 7848\n",
+      "Model inference: 4200 / 7848\n",
+      "Model inference: 4300 / 7848\n",
+      "Model inference: 4400 / 7848\n",
+      "Model inference: 4500 / 7848\n",
+      "Model inference: 4600 / 7848\n",
+      "Model inference: 4700 / 7848\n",
+      "Model inference: 4800 / 7848\n",
+      "Model inference: 4900 / 7848\n",
+      "Model inference: 5000 / 7848\n",
+      "Model inference: 5100 / 7848\n",
+      "Model inference: 5200 / 7848\n",
+      "Model inference: 5300 / 7848\n",
+      "Model inference: 5400 / 7848\n",
+      "Model inference: 5500 / 7848\n",
+      "Model inference: 5600 / 7848\n",
+      "Model inference: 5700 / 7848\n",
+      "Model inference: 5800 / 7848\n",
+      "Model inference: 5900 / 7848\n",
+      "Model inference: 6000 / 7848\n",
+      "Model inference: 6100 / 7848\n",
+      "Model inference: 6200 / 7848\n",
+      "Model inference: 6300 / 7848\n",
+      "Model inference: 6400 / 7848\n",
+      "Model inference: 6500 / 7848\n",
+      "Model inference: 6600 / 7848\n",
+      "Model inference: 6700 / 7848\n",
+      "Model inference: 6800 / 7848\n",
+      "Model inference: 6900 / 7848\n",
+      "Model inference: 7000 / 7848\n",
+      "Model inference: 7100 / 7848\n",
+      "Model inference: 7200 / 7848\n",
+      "Model inference: 7300 / 7848\n",
+      "Model inference: 7400 / 7848\n",
+      "Model inference: 7500 / 7848\n",
+      "Model inference: 7600 / 7848\n",
+      "Model inference: 7700 / 7848\n",
+      "Model inference: 7800 / 7848\n",
+      "CUDA out of memory, the new batch size is 50\n",
+      "Model inference: 7800 / 7848\n",
+      "CUDA out of memory, the new batch size is 25\n",
+      "Model inference: 7800 / 7848\n",
+      "Model inference: 7825 / 7848\n"
+     ]
+    }
+   ],
+   "source": [
+    "issue_embeddings = inference_wrapper.df_to_embedding(input_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 232,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(7848, 2400)"
+      ]
+     },
+     "execution_count": 232,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "issue_embeddings.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sanity Check the embeddings\n",
+    "\n",
+    "* We want to make sure the embeddings are computed the same way as during inference time\n",
+    "* During inference [IssueLabelerPredict.predict_labels_for_issue](https://github.com/kubeflow/code-intelligence/blob/9bbdce34fc0d81bfb9a63493941763771d2a0746/py/label_microservice/issue_label_predictor.py#L105) calls [embeddings.get_issue_text](https://github.com/kubeflow/code-intelligence/blob/9bbdce34fc0d81bfb9a63493941763771d2a0746/py/code_intelligence/embeddings.py#L36) to fetch the body and title\n",
+    "* We call embeddings.get_issue_text one of the issues to make sure it matches the data in the dataframe from which we compute the embeddings\n",
+    "* This calls the [/text on the embeddings microservice](https://github.com/kubeflow/code-intelligence/blob/9bbdce34fc0d81bfb9a63493941763771d2a0746/Issue_Embeddings/flask_app/app.py#L50)\n",
+    "\n",
+    "* TODO(https://github.com/kubeflow/code-intelligence/issues/126) The label bot microservice needs to be updated to actually\n",
+    "  use the GraphQL API to match this code. Hopefully, in the interim the model is robust to slight deviations caused\n",
+    "  by the differences in whitespace"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 233,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from code_intelligence import util as code_intelligence_util"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 234,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Fetching issue https://github.com/kubeflow/katib/issues/1062\n"
+     ]
+    }
+   ],
+   "source": [
+    "issue_index = 1020\n",
+    "logging.info(f\"Fetching issue {latest_issues.iloc[issue_index]['html_url']}\")\n",
+    "issue_owner, issue_repo, issue_num = code_intelligence_util.parse_issue_url(latest_issues.iloc[issue_index][\"html_url\"].strip(\"\\\"\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 235,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "some_issue_data = embeddings.get_issue(latest_issues.iloc[issue_index][\"html_url\"], gh_client)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 224,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'__typename': 'Issue',\n",
+       " 'author': {'__typename': 'User', 'login': 'andreyvelich'},\n",
+       " 'id': 'MDU6SXNzdWU1Njc2MjYwNjg=',\n",
+       " 'title': 'Save Suggestion state after deployment is deleted',\n",
+       " 'body': \"/kind feature\\r\\n\\r\\nKatib should have functionality to save Suggestion state somewhere besides Suggestion pod. \\r\\nSome users would like to resume Experiments, but they don't want to have always running Suggestion deployment. For example we can use PV.\\r\\n\\r\\nWe can use `ResumeExperiment` flag from here: https://github.com/kubeflow/katib/issues/1061 to specify resuming experiment mechanism.\\r\\n\\r\\n/cc @johnugeorge @gaocegege @hougangliu @richardsliu \\r\\n\",\n",
+       " 'url': 'https://github.com/kubeflow/katib/issues/1062',\n",
+       " 'state': 'OPEN',\n",
+       " 'labels': {'totalCount': 1, 'edges': [{'node': {'name': 'kind/feature'}}]}}"
+      ]
+     },
+     "execution_count": 224,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "some_issue_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 236,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Retrieved 1541 issues.\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e2681ddfc5e84aeea340b8151ca22c26",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(IntProgress(value=0, max=1541), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Save Suggestion state after deployment is deleted\n",
+      "Save Suggestion state after deployment is deleted\n",
+      "/kind feature\n",
       "\n",
-      "1526 issues remaining after minimum frequency filter of 25.\n",
-      "CPU times: user 2min 57s, sys: 42.3 s, total: 3min 39s\n",
-      "Wall time: 4min 19s\n"
+      "Katib should have functionality to save Suggestion state somewhere besides Suggestion pod. \n",
+      "Some users would like to resume Experiments, but they don't want to have always running Suggestion deployment. For example we can use PV.\n",
+      "\n",
+      "We can use `ResumeExperiment` flag from here: https://github.com/kubeflow/katib/issues/1061 to specify resuming experiment mechanism.\n",
+      "\n",
+      "/cc @johnugeorge @gaocegege @hougangliu @richardsliu \n",
+      "\n",
+      "/kind feature\n",
+      "\n",
+      "Katib should have functionality to save Suggestion state somewhere besides Suggestion pod. \n",
+      "Some users would like to resume Experiments, but they don't want to have always running Suggestion deployment. For example we can use PV.\n",
+      "\n",
+      "We can use `ResumeExperiment` flag from here: https://github.com/kubeflow/katib/issues/1061 to specify resuming experiment mechanism.\n",
+      "\n",
+      "/cc @johnugeorge @gaocegege @hougangliu @richardsliu \n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 236,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(latest_issues.iloc[issue_index][\"title\"])\n",
+    "print(some_issue_data[\"title\"])\n",
+    "print(latest_issues.iloc[issue_index][\"body\"])\n",
+    "print(some_issue_data[\"body\"])\n",
+    "some_issue_data[\"title\"] == latest_issues.iloc[issue_index][\"title\"]\n",
+    "some_issue_data[\"body\"] == latest_issues.iloc[issue_index][\"body\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Compare the embeddings computed in this notebook to the embeddings computed using inference_wrapper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 237,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dict_for_embeddings = inference_wrapper.process_dict(some_issue_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 238,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[-0.006017, -0.113368, -0.04294 ,  0.124138, ..., -0.017082, -0.245775, -0.077704,  0.084911]], dtype=float32)"
+      ]
+     },
+     "execution_count": 238,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "inference_wrapper.get_pooled_features(dict_for_embeddings['text']).detach().cpu().numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 239,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-0.006017, -0.113368, -0.04294 ,  0.124138, ..., -0.017082, -0.245775, -0.077705,  0.084911], dtype=float32)"
+      ]
+     },
+     "execution_count": 239,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "issue_embeddings[issue_index,:]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save the issues and embeddings to an HDF5 file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 263,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import h5py\n",
+    "import datetime\n",
+    "\n",
+    "now = code_intelligence_util.now().isoformat()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 268,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "git_tag = subprocess.check_output([\"git\", \"describe\", \"--tags\", \"--always\", \"--dirty\"]).decode().strip()\n",
+    "file_name = f\"kubeflow_issue_embeddings_{now}.hdf5\"\n",
+    "local_file = os.path.join(home, file_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 269,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jovyan/.local/lib/python3.6/site-packages/pandas/core/generic.py:2377: PerformanceWarning: \n",
+      "your performance may suffer as PyTables will pickle object types that it cannot\n",
+      "map directly to c-types [inferred_type->mixed,key->block0_values] [items->['html_url', 'title', 'body', 'labels', 'updated_at', 'login', 'type', 'parsed_labels']]\n",
+      "\n",
+      "  return pytables.to_hdf(path_or_buf, key, self, **kwargs)\n"
      ]
     }
    ],
    "source": [
-    "%%time\n",
-    "test = get_all_issue_text(owner='kubeflow', repo='kubeflow', inf_wrapper=inference_wrapper)"
+    "latest_issues.to_hdf(local_file, \"issues\", mode=\"a\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 270,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h5_file = h5py.File(local_file, mode=\"a\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 271,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(1526, 1600)"
+       "<HDF5 dataset \"issue_embeddings\": shape (7848, 2400), type \"<f4\">"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 271,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "test['features'].shape"
+    "h5_file.create_dataset(\"issue_embeddings\", data=issue_embeddings)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 272,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# store some metadata\n",
+    "h5_file.attrs[\"file\"] = \"Get-GitHub-Issues.ipynb\"\n",
+    "h5_file.attrs[\"git-tag\"] = git_tag "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 273,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h5_file.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save Embeddings to GCS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 274,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Copying /home/jovyan/kubeflow_issue_embeddings_2020-04-11T17:15:10.000876-07:00.hdf5 to gs://repo-embeddings/kubeflow/2020_0428/kubeflow_issue_embeddings_2020-04-11T17:15:10.000876-07:00.hdf5\n"
+     ]
+    }
+   ],
+   "source": [
+    "embeddings_file = os.path.join(embeddings_dir, file_name)\n",
+    "if gcs_util.check_gcs_object(embeddings_file):\n",
+    "    logging.info(f\"File {embeddings_file} exists\")\n",
+    "else:    \n",
+    "    logging.info(f\"Copying {local_file} to {embeddings_file}\")         \n",
+    "    gcs_util.copy_to_gcs(local_file, embeddings_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1526"
+       "'gs://repo-embeddings/kubeflow/2020_0428/kubeflow_embeddings_200410_162421.h5'"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "len(test['labels'])"
+    "embeddings_file"
    ]
   },
   {
@@ -335,13 +1049,6 @@
     "\n",
     "It takes 4min to retrieve embeddings and labels for `Kubeflow\\Kubeflow` this time can likely be brought down to 1 minute by batching the text instead of feeding the language model one by one.  "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -360,9 +1067,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/Issue_Embeddings/requirements.txt
+++ b/Issue_Embeddings/requirements.txt
@@ -17,6 +17,7 @@ cymem==2.0.2
 cytoolz==0.9.0.1
 decorator==4.4.0
 defusedxml==0.6.0
+dill==0.3.0
 entrypoints==0.3
 fastai==1.0.53.post3
 fastprogress==0.1.21
@@ -24,8 +25,10 @@ flask-session==0.3.1
 flask==1.0.2
 ftfy==4.4.3
 gcsfs==0.2.1
-google-auth-oauthlib==0.3.0
-google-auth==1.6.3
+github3.py>=1.3.0
+google-auth-oauthlib
+google-auth
+google-cloud-bigquery
 gunicorn==19.9.0
 html5lib==1.0.1
 idna==2.8
@@ -40,6 +43,7 @@ jedi==0.13.3
 jinja2==2.10.1
 joblib==0.13.2
 jsonschema==3.0.1
+JSON-log-formatter==0.2.0
 jupyter-client==5.2.4
 jupyter-core==4.4.0
 kiwisolver==1.1.0
@@ -47,6 +51,7 @@ markupsafe==1.1.1
 matplotlib==3.0.3
 mdparse==0.13
 mistune==0.8.4
+more-itertools==8.2.0
 murmurhash==1.0.2
 mwparserfromhell==0.5.3
 nbconvert==5.5.0
@@ -58,6 +63,7 @@ numpy==1.16.4
 oauthlib==3.0.1
 packaging==19.0
 pandas==0.24.2
+pandas-gbq 
 pandocfilters==1.4.2
 parso==0.4.0
 passlib==1.7.1
@@ -89,10 +95,11 @@ rsa==4.0
 scikit-learn==0.20.3
 scipy==1.2.1
 send2trash==1.5.0
-six==1.12.0
+six>=1.13.0
 soupsieve==1.9.1
 spacy==2.1.4
 srsly==0.0.7
+tables
 terminado==0.8.2
 testpath==0.4.2
 textacy==0.7.1
@@ -100,6 +107,7 @@ thinc==7.0.4
 timeout-decorator==0.4.1
 toolz==0.9.0
 tornado==6.0.2
+torch==1.1.0
 tqdm==4.32.2
 traitlets==4.3.2
 typing==3.6.6

--- a/Issue_Triage/notebooks/metrics.ipynb
+++ b/Issue_Triage/notebooks/metrics.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 312,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -20,7 +20,7 @@
        "RendererRegistry.enable('html')"
       ]
      },
-     "execution_count": 312,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,9 +93,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jovyan/.local/lib/python3.6/site-packages/pandas_gbq/gbq.py:555: UserWarning: A progress bar was requested, but there was an error loading the tqdm library. Please install tqdm to use the progress bar functionality.\n",
+      "  progress_bar_type=progress_bar_type,\n"
+     ]
+    }
+   ],
    "source": [
     "query = \"\"\"\n",
     "SELECT\n",
@@ -113,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 214,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 215,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 247,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 248,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 249,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 254,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,14 +249,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 255,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total # of issues 24\n",
+      "Total # of issues 702\n",
       "Number and precentage of issues with labels with various prefixes\n"
      ]
     },
@@ -281,8 +290,8 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>area</td>\n",
-       "      <td>1</td>\n",
-       "      <td>4.166667</td>\n",
+       "      <td>10</td>\n",
+       "      <td>1.424501</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -293,8 +302,8 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>kind</td>\n",
-       "      <td>23</td>\n",
-       "      <td>95.833333</td>\n",
+       "      <td>655</td>\n",
+       "      <td>93.304843</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -302,12 +311,12 @@
       ],
       "text/plain": [
        "      label  count  percentage\n",
-       "0      area      1    4.166667\n",
+       "0      area     10    1.424501\n",
        "1  platform      0    0.000000\n",
-       "2      kind     23   95.833333"
+       "2      kind    655   93.304843"
       ]
      },
-     "execution_count": 255,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -320,17 +329,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 313,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-d251d2f8fc924987bdcde6785869f627\"></div>\n",
+       "<div id=\"altair-viz-84432cb640954772bd405994958b5a7b\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  (function(spec, embedOpt){\n",
-       "    const outputDiv = document.getElementById(\"altair-viz-d251d2f8fc924987bdcde6785869f627\");\n",
+       "    const outputDiv = document.getElementById(\"altair-viz-84432cb640954772bd405994958b5a7b\");\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
        "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
@@ -371,14 +380,14 @@
        "        .catch(showError)\n",
        "        .then(() => displayChart(vegaEmbed));\n",
        "    }\n",
-       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-4451d8e017c39fe7d73f407358e493ab\"}, \"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"nominal\", \"field\": \"label\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"count\"}}, \"selection\": {\"selector012\": {\"type\": \"interval\", \"bind\": \"scales\", \"encodings\": [\"x\", \"y\"]}}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-4451d8e017c39fe7d73f407358e493ab\": [{\"label\": \"area\", \"count\": 1, \"percentage\": 4.166666666666666}, {\"label\": \"platform\", \"count\": 0, \"percentage\": 0.0}, {\"label\": \"kind\", \"count\": 23, \"percentage\": 95.83333333333334}]}}, {\"mode\": \"vega-lite\"});\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"data\": {\"name\": \"data-6e9be022f6f73724ea217cad7870312d\"}, \"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"nominal\", \"field\": \"label\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"count\"}}, \"selection\": {\"selector001\": {\"type\": \"interval\", \"bind\": \"scales\", \"encodings\": [\"x\", \"y\"]}}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-6e9be022f6f73724ea217cad7870312d\": [{\"label\": \"area\", \"count\": 10, \"percentage\": 1.4245014245014245}, {\"label\": \"platform\", \"count\": 0, \"percentage\": 0.0}, {\"label\": \"kind\", \"count\": 655, \"percentage\": 93.30484330484332}]}}, {\"mode\": \"vega-lite\"});\n",
        "</script>"
       ],
       "text/plain": [
        "alt.Chart(...)"
       ]
      },
-     "execution_count": 313,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -402,18 +411,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 300,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.7/dist-packages/ipykernel_launcher.py:8: SettingWithCopyWarning: \n",
+      "/usr/local/lib/python3.6/dist-packages/ipykernel_launcher.py:8: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
-      "See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
       "  \n"
      ]
     }
@@ -432,17 +441,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 316,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
        "\n",
-       "<div id=\"altair-viz-fc20cd2740164d27b694b30edf4d2385\"></div>\n",
+       "<div id=\"altair-viz-b9b9735f32264f558d6fd8784c364310\"></div>\n",
        "<script type=\"text/javascript\">\n",
        "  (function(spec, embedOpt){\n",
-       "    const outputDiv = document.getElementById(\"altair-viz-fc20cd2740164d27b694b30edf4d2385\");\n",
+       "    const outputDiv = document.getElementById(\"altair-viz-b9b9735f32264f558d6fd8784c364310\");\n",
        "    const paths = {\n",
        "      \"vega\": \"https://cdn.jsdelivr.net/npm//vega@5?noext\",\n",
        "      \"vega-lib\": \"https://cdn.jsdelivr.net/npm//vega-lib?noext\",\n",
@@ -483,14 +492,14 @@
        "        .catch(showError)\n",
        "        .then(() => displayChart(vegaEmbed));\n",
        "    }\n",
-       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"layer\": [{\"mark\": \"line\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}}, {\"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}}], \"data\": {\"name\": \"data-bcab1200d103f404c02e000cf7142a4c\"}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-bcab1200d103f404c02e000cf7142a4c\": [{\"day\": \"2020-01-03T00:00:00\", \"num_issues\": 5}, {\"day\": \"2020-01-17T00:00:00\", \"num_issues\": 10}, {\"day\": \"2020-01-18T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-19T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-20T00:00:00\", \"num_issues\": 7}]}}, {\"mode\": \"vega-lite\"});\n",
+       "  })({\"config\": {\"view\": {\"continuousWidth\": 400, \"continuousHeight\": 300}}, \"layer\": [{\"mark\": \"line\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}, \"selection\": {\"selector002\": {\"type\": \"interval\", \"bind\": \"scales\", \"encodings\": [\"x\", \"y\"]}}}, {\"mark\": \"point\", \"encoding\": {\"x\": {\"type\": \"temporal\", \"field\": \"day\"}, \"y\": {\"type\": \"quantitative\", \"field\": \"num_issues\"}}}], \"data\": {\"name\": \"data-8a4f2a8bad3630a9969e40c6ef5a6ad1\"}, \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.0.2.json\", \"datasets\": {\"data-8a4f2a8bad3630a9969e40c6ef5a6ad1\": [{\"day\": \"2020-01-03T00:00:00\", \"num_issues\": 5}, {\"day\": \"2020-01-17T00:00:00\", \"num_issues\": 10}, {\"day\": \"2020-01-18T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-19T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-20T00:00:00\", \"num_issues\": 10}, {\"day\": \"2020-01-21T00:00:00\", \"num_issues\": 8}, {\"day\": \"2020-01-22T00:00:00\", \"num_issues\": 11}, {\"day\": \"2020-01-23T00:00:00\", \"num_issues\": 10}, {\"day\": \"2020-01-24T00:00:00\", \"num_issues\": 8}, {\"day\": \"2020-01-25T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-01-26T00:00:00\", \"num_issues\": 2}, {\"day\": \"2020-01-27T00:00:00\", \"num_issues\": 5}, {\"day\": \"2020-01-28T00:00:00\", \"num_issues\": 13}, {\"day\": \"2020-01-29T00:00:00\", \"num_issues\": 20}, {\"day\": \"2020-01-30T00:00:00\", \"num_issues\": 17}, {\"day\": \"2020-01-31T00:00:00\", \"num_issues\": 13}, {\"day\": \"2020-02-01T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-02-02T00:00:00\", \"num_issues\": 7}, {\"day\": \"2020-02-03T00:00:00\", \"num_issues\": 13}, {\"day\": \"2020-02-04T00:00:00\", \"num_issues\": 15}, {\"day\": \"2020-02-05T00:00:00\", \"num_issues\": 15}, {\"day\": \"2020-02-06T00:00:00\", \"num_issues\": 7}, {\"day\": \"2020-02-07T00:00:00\", \"num_issues\": 9}, {\"day\": \"2020-02-08T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-02-09T00:00:00\", \"num_issues\": 9}, {\"day\": \"2020-02-10T00:00:00\", \"num_issues\": 15}, {\"day\": \"2020-02-11T00:00:00\", \"num_issues\": 16}, {\"day\": \"2020-02-12T00:00:00\", \"num_issues\": 25}, {\"day\": \"2020-02-13T00:00:00\", \"num_issues\": 16}, {\"day\": \"2020-02-14T00:00:00\", \"num_issues\": 15}, {\"day\": \"2020-02-15T00:00:00\", \"num_issues\": 2}, {\"day\": \"2020-02-16T00:00:00\", \"num_issues\": 3}, {\"day\": \"2020-02-17T00:00:00\", \"num_issues\": 9}, {\"day\": \"2020-02-18T00:00:00\", \"num_issues\": 7}, {\"day\": \"2020-02-19T00:00:00\", \"num_issues\": 16}, {\"day\": \"2020-02-20T00:00:00\", \"num_issues\": 10}, {\"day\": \"2020-02-21T00:00:00\", \"num_issues\": 7}, {\"day\": \"2020-02-22T00:00:00\", \"num_issues\": 2}, {\"day\": \"2020-02-23T00:00:00\", \"num_issues\": 4}, {\"day\": \"2020-02-24T00:00:00\", \"num_issues\": 15}, {\"day\": \"2020-02-25T00:00:00\", \"num_issues\": 4}, {\"day\": \"2020-02-26T00:00:00\", \"num_issues\": 8}, {\"day\": \"2020-02-27T00:00:00\", \"num_issues\": 9}, {\"day\": \"2020-02-28T00:00:00\", \"num_issues\": 11}, {\"day\": \"2020-02-29T00:00:00\", \"num_issues\": 2}, {\"day\": \"2020-03-01T00:00:00\", \"num_issues\": 3}, {\"day\": \"2020-03-02T00:00:00\", \"num_issues\": 8}, {\"day\": \"2020-03-03T00:00:00\", \"num_issues\": 13}, {\"day\": \"2020-03-04T00:00:00\", \"num_issues\": 17}, {\"day\": \"2020-03-05T00:00:00\", \"num_issues\": 9}, {\"day\": \"2020-03-06T00:00:00\", \"num_issues\": 5}, {\"day\": \"2020-03-07T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-03-08T00:00:00\", \"num_issues\": 4}, {\"day\": \"2020-03-09T00:00:00\", \"num_issues\": 11}, {\"day\": \"2020-03-10T00:00:00\", \"num_issues\": 14}, {\"day\": \"2020-03-11T00:00:00\", \"num_issues\": 14}, {\"day\": \"2020-03-12T00:00:00\", \"num_issues\": 14}, {\"day\": \"2020-03-13T00:00:00\", \"num_issues\": 14}, {\"day\": \"2020-03-14T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-03-15T00:00:00\", \"num_issues\": 6}, {\"day\": \"2020-03-16T00:00:00\", \"num_issues\": 18}, {\"day\": \"2020-03-17T00:00:00\", \"num_issues\": 12}, {\"day\": \"2020-03-18T00:00:00\", \"num_issues\": 13}, {\"day\": \"2020-03-19T00:00:00\", \"num_issues\": 7}, {\"day\": \"2020-03-20T00:00:00\", \"num_issues\": 13}, {\"day\": \"2020-03-21T00:00:00\", \"num_issues\": 3}, {\"day\": \"2020-03-22T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-03-23T00:00:00\", \"num_issues\": 14}, {\"day\": \"2020-03-24T00:00:00\", \"num_issues\": 13}, {\"day\": \"2020-03-25T00:00:00\", \"num_issues\": 6}, {\"day\": \"2020-03-26T00:00:00\", \"num_issues\": 9}, {\"day\": \"2020-03-27T00:00:00\", \"num_issues\": 7}, {\"day\": \"2020-03-29T00:00:00\", \"num_issues\": 1}, {\"day\": \"2020-03-30T00:00:00\", \"num_issues\": 7}, {\"day\": \"2020-03-31T00:00:00\", \"num_issues\": 4}, {\"day\": \"2020-04-01T00:00:00\", \"num_issues\": 6}, {\"day\": \"2020-04-02T00:00:00\", \"num_issues\": 8}, {\"day\": \"2020-04-03T00:00:00\", \"num_issues\": 12}, {\"day\": \"2020-04-04T00:00:00\", \"num_issues\": 2}, {\"day\": \"2020-04-05T00:00:00\", \"num_issues\": 3}, {\"day\": \"2020-04-06T00:00:00\", \"num_issues\": 1}]}}, {\"mode\": \"vega-lite\"});\n",
        "</script>"
       ],
       "text/plain": [
        "alt.LayerChart(...)"
       ]
      },
-     "execution_count": 316,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -504,9 +513,7 @@
     "\n",
     "point = line + line.mark_point()\n",
     "\n",
-    "# Try turning off interactive mode to see if it renders in GitHub preview.\n",
-    "point\n",
-    "# point.interactive()"
+    "point.interactive()"
    ]
   }
  ],
@@ -526,9 +533,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5rc1"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/Issue_Triage/notebooks/triage.ipynb
+++ b/Issue_Triage/notebooks/triage.ipynb
@@ -254,13 +254,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:37:29|Issue https://github.com/kubeflow/examples/issues/176:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:37:29|Issue https://github.com/kubeflow/examples/issues/181:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -380,13 +374,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:37:38|Issue https://github.com/kubeflow/examples/issues/319:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:37:38|Issue https://github.com/kubeflow/examples/issues/329:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -510,13 +498,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:37:43|Issue https://github.com/kubeflow/examples/issues/547:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:37:43|Issue https://github.com/kubeflow/examples/issues/549:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -642,13 +624,7 @@
       "\t Issue needs a kind label\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:37:52|Issue https://github.com/kubeflow/examples/issues/636:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -781,13 +757,7 @@
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
-      "INFO|2019-11-26T15:38:15|Issue: https://github.com/kubeflow/fairing/issues/196; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "INFO|2019-11-26T15:38:15|Issue: https://github.com/kubeflow/fairing/issues/196; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:38:16|Issue https://github.com/kubeflow/fairing/issues/196:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -919,13 +889,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:38:28|Issue https://github.com/kubeflow/fairing/issues/304:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:38:28|Issue https://github.com/kubeflow/fairing/issues/307:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
@@ -1057,13 +1021,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:38:45|Issue https://github.com/kubeflow/fairing/issues/382:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:38:45|Issue https://github.com/kubeflow/fairing/issues/383:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -1179,13 +1137,7 @@
       "INFO|2019-11-26T15:39:04|Issue: https://github.com/kubeflow/kubeflow/issues/1394; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:39:05|Issue https://github.com/kubeflow/kubeflow/issues/1394:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:39:05|Issue: https://github.com/kubeflow/kubeflow/issues/1398; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:39:07|Issue https://github.com/kubeflow/kubeflow/issues/1398:\n",
       "state:Issue doesn't need attention.\n",
@@ -1291,13 +1243,7 @@
       "INFO|2019-11-26T15:39:22|Issue: https://github.com/kubeflow/kubeflow/issues/2311; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:39:25|Issue https://github.com/kubeflow/kubeflow/issues/2311:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:39:25|Issue: https://github.com/kubeflow/kubeflow/issues/2337; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:39:26|Issue https://github.com/kubeflow/kubeflow/issues/2337:\n",
       "state:Issue doesn't need attention.\n",
@@ -1405,13 +1351,7 @@
       "INFO|2019-11-26T15:39:38|Issue https://github.com/kubeflow/kubeflow/issues/2628:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
-      "INFO|2019-11-26T15:39:38|Issue: https://github.com/kubeflow/kubeflow/issues/2630; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "INFO|2019-11-26T15:39:38|Issue: https://github.com/kubeflow/kubeflow/issues/2630; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:39:39|Issue https://github.com/kubeflow/kubeflow/issues/2630:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -1529,13 +1469,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:39:52|Issue https://github.com/kubeflow/kubeflow/issues/2842:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:39:52|Issue https://github.com/kubeflow/kubeflow/issues/2843:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -1647,13 +1581,7 @@
       "INFO|2019-11-26T15:40:04|Issue: https://github.com/kubeflow/kubeflow/issues/2998; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:40:06|Issue https://github.com/kubeflow/kubeflow/issues/2998:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:40:06|Issue https://github.com/kubeflow/kubeflow/issues/3003:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -1763,13 +1691,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:40:19|Issue https://github.com/kubeflow/kubeflow/issues/3099:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:40:19|Issue https://github.com/kubeflow/kubeflow/issues/3105:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -1885,13 +1807,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:40:33|Issue https://github.com/kubeflow/kubeflow/issues/3223:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:40:33|Issue https://github.com/kubeflow/kubeflow/issues/3226:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -2010,13 +1926,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:40:39|Issue https://github.com/kubeflow/kubeflow/issues/3367:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:40:39|Issue https://github.com/kubeflow/kubeflow/issues/3368:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -2131,13 +2041,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:40:47|Issue https://github.com/kubeflow/kubeflow/issues/3452:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:40:47|Issue https://github.com/kubeflow/kubeflow/issues/3453:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -2246,13 +2150,7 @@
       "INFO|2019-11-26T15:41:07|Issue https://github.com/kubeflow/kubeflow/issues/3512 already in triage project|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|751|\n",
       "INFO|2019-11-26T15:41:07|Issue https://github.com/kubeflow/kubeflow/issues/3516:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:41:07|Issue https://github.com/kubeflow/kubeflow/issues/3517:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -2368,13 +2266,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:41:18|Issue https://github.com/kubeflow/kubeflow/issues/3567:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:41:18|Issue https://github.com/kubeflow/kubeflow/issues/3568:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -2491,13 +2383,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:41:25|Issue https://github.com/kubeflow/kubeflow/issues/3624:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:41:25|Issue https://github.com/kubeflow/kubeflow/issues/3625:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -2611,13 +2497,7 @@
       "INFO|2019-11-26T15:41:40|Issue: https://github.com/kubeflow/kubeflow/issues/3686; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:41:41|Issue https://github.com/kubeflow/kubeflow/issues/3686:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:41:41|Issue https://github.com/kubeflow/kubeflow/issues/3687:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -2731,13 +2611,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:41:56|Issue https://github.com/kubeflow/kubeflow/issues/3738:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:41:56|Issue: https://github.com/kubeflow/kubeflow/issues/3739; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:41:57|Issue https://github.com/kubeflow/kubeflow/issues/3739:\n",
       "state:Issue doesn't need attention.\n",
@@ -2843,13 +2717,7 @@
       "INFO|2019-11-26T15:42:12|Issue https://github.com/kubeflow/kubeflow/issues/3788:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
-      "INFO|2019-11-26T15:42:20|Processing shard 5|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|539|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "INFO|2019-11-26T15:42:20|Processing shard 5|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|539|\n",
       "INFO|2019-11-26T15:42:20|Issue https://github.com/kubeflow/kubeflow/issues/3789:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -2965,13 +2833,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:42:31|Issue https://github.com/kubeflow/kubeflow/issues/3834:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:42:31|Issue https://github.com/kubeflow/kubeflow/issues/3835:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -3085,13 +2947,7 @@
       "INFO|2019-11-26T15:42:45|Issue https://github.com/kubeflow/kubeflow/issues/3891:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
-      "INFO|2019-11-26T15:42:45|Issue: https://github.com/kubeflow/kubeflow/issues/3893; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "INFO|2019-11-26T15:42:45|Issue: https://github.com/kubeflow/kubeflow/issues/3893; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:42:46|Issue https://github.com/kubeflow/kubeflow/issues/3893:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -3203,13 +3059,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:43:07|Issue https://github.com/kubeflow/kubeflow/issues/3950:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:43:07|Issue https://github.com/kubeflow/kubeflow/issues/3951:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -3330,13 +3180,7 @@
       "INFO|2019-11-26T15:43:11|Issue: https://github.com/kubeflow/kubeflow/issues/4025; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:43:12|Issue https://github.com/kubeflow/kubeflow/issues/4025:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:43:12|Issue https://github.com/kubeflow/kubeflow/issues/4026:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -3460,13 +3304,7 @@
       "INFO|2019-11-26T15:43:16|Issue https://github.com/kubeflow/kubeflow/issues/4078:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:43:16|Issue https://github.com/kubeflow/kubeflow/issues/4078 already in triage project|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|751|\n",
       "INFO|2019-11-26T15:43:16|Issue https://github.com/kubeflow/kubeflow/issues/4079:\n",
       "state:Issue doesn't need attention.\n",
@@ -3580,13 +3418,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:43:34|Issue https://github.com/kubeflow/kubeflow/issues/4142:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:43:34|Issue https://github.com/kubeflow/kubeflow/issues/4144:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -3709,13 +3541,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:43:39|Issue https://github.com/kubeflow/kubeflow/issues/4217:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:43:39|Issue: https://github.com/kubeflow/kubeflow/issues/4221; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:43:40|Issue https://github.com/kubeflow/kubeflow/issues/4221:\n",
       "state:Issue doesn't need attention.\n",
@@ -3824,13 +3650,7 @@
       "state:Issue needs triage:\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:43:52|Issue https://github.com/kubeflow/kubeflow/issues/4291 already in triage project|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|751|\n",
       "INFO|2019-11-26T15:43:52|Issue https://github.com/kubeflow/kubeflow/issues/4292:\n",
       "state:Issue doesn't need attention.\n",
@@ -3931,13 +3751,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:44:04|Issue https://github.com/kubeflow/kubeflow/issues/4348:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:44:04|Issue https://github.com/kubeflow/kubeflow/issues/4353:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -4046,13 +3860,7 @@
       "INFO|2019-11-26T15:44:09|Issue: https://github.com/kubeflow/kubeflow/issues/4410; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:44:10|Issue https://github.com/kubeflow/kubeflow/issues/4410:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:44:10|Issue https://github.com/kubeflow/kubeflow/issues/4411:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -4169,13 +3977,7 @@
       "state:Issue needs triage:\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:44:20|Issue https://github.com/kubeflow/kubeflow/issues/4488:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -4308,13 +4110,7 @@
       "INFO|2019-11-26T15:44:43|Issue https://github.com/kubeflow/kubeflow/issues/4524:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:44:44|Issue https://github.com/kubeflow/kubeflow/issues/4527:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -4441,13 +4237,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:45:00|Issue https://github.com/kubeflow/kfserving/issues/160:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:45:00|Issue https://github.com/kubeflow/kfserving/issues/161:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -4576,13 +4366,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:45:12|Issue https://github.com/kubeflow/kfserving/issues/269:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:45:12|Issue https://github.com/kubeflow/kfserving/issues/270:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs a kind label\n",
@@ -4717,13 +4501,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:45:28|Issue https://github.com/kubeflow/kfserving/issues/338:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:45:33|Processing shard 1|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|539|\n",
       "INFO|2019-11-26T15:45:33|Issue https://github.com/kubeflow/kfserving/issues/341:\n",
       "state:Issue needs triage:\n",
@@ -4856,13 +4634,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:45:54|Issue https://github.com/kubeflow/kfserving/issues/413:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:45:54|Issue https://github.com/kubeflow/kfserving/issues/414:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -4995,13 +4767,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:46:12|Issue https://github.com/kubeflow/kfserving/issues/489:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:46:12|Issue https://github.com/kubeflow/kfserving/issues/490:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -5137,13 +4903,7 @@
       "\t Issue needs a kind label\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:46:34|Processing shard 2|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|539|\n",
       "INFO|2019-11-26T15:46:34|Issue https://github.com/kubeflow/kfserving/issues/565:\n",
       "state:Issue doesn't need attention.\n",
@@ -5280,13 +5040,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:46:56|Issue https://github.com/kubeflow/manifests/issues/152:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:46:56|Issue https://github.com/kubeflow/manifests/issues/164:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs a kind label\n",
@@ -5424,13 +5178,7 @@
       "\t Issue needs a kind label\n",
       "\t Issue needs an area label\n",
       "\t Issues with priority in ['priority/p0', 'priority/p1'] need to be assigned to a project\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:47:18|Issue https://github.com/kubeflow/manifests/issues/296:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs a kind label\n",
@@ -5574,13 +5322,7 @@
       "\t Issue needs a kind label\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:47:41|Issue https://github.com/kubeflow/manifests/issues/425:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs an area label\n",
@@ -5712,13 +5454,7 @@
       "\t Issue needs a kind label\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:47:57|Issue https://github.com/kubeflow/manifests/issues/521:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs an area label\n",
@@ -5851,13 +5587,7 @@
       "INFO|2019-11-26T15:48:24|Issue: https://github.com/kubeflow/metadata/issues/6; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:48:25|Issue https://github.com/kubeflow/metadata/issues/6:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:48:25|Issue: https://github.com/kubeflow/metadata/issues/7; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:48:26|Issue https://github.com/kubeflow/metadata/issues/7:\n",
       "state:Issue doesn't need attention.\n",
@@ -5994,13 +5724,7 @@
       "state:Issue needs triage:\n",
       "\t Issue needs a kind label\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:48:47|Issue https://github.com/kubeflow/metadata/issues/117:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs a kind label\n",
@@ -6133,13 +5857,7 @@
       "state:Issue needs triage:\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:49:23|kubeflow/pytorch-operator has a total of 18 issues|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|374|\n",
       "INFO|2019-11-26T15:49:23|Processing shard 0|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|539|\n",
       "INFO|2019-11-26T15:49:23|Issue https://github.com/kubeflow/pytorch-operator/issues/89:\n",
@@ -6263,13 +5981,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:49:44|Issue https://github.com/kubeflow/testing/issues/88:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:49:44|Issue https://github.com/kubeflow/testing/issues/103:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -6404,13 +6116,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:49:57|Issue https://github.com/kubeflow/testing/issues/380:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:49:57|Issue https://github.com/kubeflow/testing/issues/391:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -6542,13 +6248,7 @@
       "\t Issue needs a kind label\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:50:23|Issue https://github.com/kubeflow/testing/issues/471:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs a kind label\n",
@@ -6671,13 +6371,7 @@
       "state:Issue needs triage:\n",
       "\t Issue needs an area label\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
-      "INFO|2019-11-26T15:50:54|Issue: https://github.com/kubeflow/tf-operator/issues/622; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "INFO|2019-11-26T15:50:54|Issue: https://github.com/kubeflow/tf-operator/issues/622; fetching all timeline items|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|672|\n",
       "INFO|2019-11-26T15:50:55|Issue https://github.com/kubeflow/tf-operator/issues/622:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -6795,13 +6489,7 @@
       "state:Issue needs triage:\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:51:26|Issue https://github.com/kubeflow/tf-operator/issues/1031:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -6930,13 +6618,7 @@
       "\t Issue needs a kind label\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:51:53|Issue https://github.com/kubeflow/website/issues/210:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs a kind label\n",
@@ -7070,13 +6752,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:52:14|Issue https://github.com/kubeflow/website/issues/758:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:52:14|Issue https://github.com/kubeflow/website/issues/761:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -7205,13 +6881,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:52:39|Issue https://github.com/kubeflow/website/issues/847:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:52:39|Issue https://github.com/kubeflow/website/issues/849:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -7340,13 +7010,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:53:10|Issue https://github.com/kubeflow/website/issues/900:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:53:10|Issue https://github.com/kubeflow/website/issues/901:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -7480,13 +7144,7 @@
       "INFO|2019-11-26T15:53:23|Issue https://github.com/kubeflow/website/issues/994:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:53:25|Issue https://github.com/kubeflow/website/issues/995:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -7618,13 +7276,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:53:37|Issue https://github.com/kubeflow/website/issues/1092:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:53:37|Issue https://github.com/kubeflow/website/issues/1094:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs a kind label\n",
@@ -7756,13 +7408,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:54:04|Issue https://github.com/kubeflow/website/issues/1165:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:54:04|Issue https://github.com/kubeflow/website/issues/1166:\n",
       "state:Issue needs triage:\n",
       "\t Issue needs a kind label\n",
@@ -7895,13 +7541,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:54:32|Issue https://github.com/kubeflow/website/issues/1225:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:54:32|Issue https://github.com/kubeflow/website/issues/1226:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -8031,13 +7671,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:54:54|Issue https://github.com/kubeflow/website/issues/1311:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:54:54|Issue https://github.com/kubeflow/website/issues/1312:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -8163,13 +7797,7 @@
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:55:03|Issue https://github.com/kubeflow/website/issues/1375:\n",
       "state:Issue doesn't need attention.\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
       "INFO|2019-11-26T15:55:03|Issue https://github.com/kubeflow/website/issues/1381:\n",
       "state:Issue doesn't need attention.\n",
       "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|677|\n",
@@ -8339,13 +7967,7 @@
       "state:Issue needs triage:\n",
       "\t Issue needs one of the priorities ['priority/p0', 'priority/p1', 'priority/p2', 'priority/p3']\n",
       "\t Issue needs an area label\n",
-      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|682|\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|682|\n",
       "INFO|2019-11-04T09:49:45|Issue https://github.com/kubeflow/kubeflow/issues/4324 already in triage project|/home/jlewi/git_kubeflow-code-intelligence/py/issue_triage/triage.py|758|\n",
       "INFO|2019-11-04T09:49:45|Issue https://github.com/kubeflow/kubeflow/issues/4316:\n",
       "state:Issue needs triage:\n",
@@ -8770,9 +8392,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5rc1"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/Label_Microservice/notebooks/issues_loader.ipynb
+++ b/Label_Microservice/notebooks/issues_loader.ipynb
@@ -179,9 +179,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/train_kubeflow_label_model.md
+++ b/docs/train_kubeflow_label_model.md
@@ -1,0 +1,21 @@
+# Training a Label Bot Model For Kubeflow
+
+These are instructions/pointers for how to train and deploy a Kubeflow specific
+model trained on all Kubeflow repositories.
+
+A lot of relevant information is in various issues:
+
+* [kubeflow/code-intelligence#110](https://github.com/kubeflow/code-intelligence/issues/110) Train an org wide model
+* [kubeflow/code-intelligence#70](https://github.com/kubeflow/code-intelligence/issues/70) Ensemble model combining repo specific models
+  and global model
+  
+
+These notes are in complete as training and deploying an org wide model is still a work in progress; see [kubeflow/code-intelligence#110](https://github.com/kubeflow/code-intelligence/issues/110)
+
+## Build Training set and compute embeddings
+
+* Use the notebook [../Issue_Embeddings/notebooks/Get-GitHub-Issues.ipynb](../Issue_Embeddings/notebooks/Get-GitHub-Issues.ipynb) to
+
+  * Fetch all issues for kubeflow from BigQuery
+  * Compute embeddings for all Kubeflow issues
+  * Save the data to an HDF5 file on GCS

--- a/py/code_intelligence/embeddings.py
+++ b/py/code_intelligence/embeddings.py
@@ -32,7 +32,7 @@ def find_max_issue_num(owner, repo):
     return int(issue_num)
 
 # TODO(jlewi): Looks like idx isn't used can we remove it?
-# TODO(jlewi): Should we use the GitHub API rather than using the web?
+# TODO(https://github.com/kubeflow/code-intelligence/issues/126): Should we use the GitHub API rather than using the web?
 def get_issue_text(num, idx, owner, repo, skip_issue=True):
     """
     Get the raw text of an issue body and label.
@@ -73,6 +73,60 @@ def get_issue_text(num, idx, owner, repo, skip_issue=True):
             'labels': labels,
             'num': num}
 
+# TODO(https://github.com/kubeflow/code-intelligence/issues/126): This function should replace
+# get_issue_text
+def get_issue(url, gh_client):
+  """Fetch the issue data using GraphQL
+  
+  Args:
+    url: Url of the GitHub isue to fetch
+    gh_client: GitHub GraphQl client.
+    
+  Returns
+    ------
+    dict
+        {'title':str, 'body':str}
+  """
+  issue_query = """query getIssue($url: URI!) {
+  resource(url: $url) {
+    __typename
+    ... on Issue {
+      author {
+        __typename
+        ... on User {
+          login
+        }
+        ... on Bot {
+          login
+        }
+      }
+      id
+      title
+      body
+      url
+      state
+      labels(first: 30) {
+        totalCount
+        edges {
+          node {
+            name
+          }
+        }
+      }
+    }
+  }
+}"""
+
+  variables = {
+          "url": url,
+  }
+  issue_results = gh_client.run_query(issue_query, variables)
+  
+  if "errors" in issue_results:
+    logging.error(f"There was a problem running the github query; {issue_results['errors']}")
+    raise ValueError(f"There was a problem running the github query: {issue_results['errors']}")
+  return issue_results["data"]["resource"]
+  
 def get_all_issue_text(owner, repo, inf_wrapper, workers=64):
     """
     Prepare embedding features of all issues in a given repository.
@@ -90,11 +144,13 @@ def get_all_issue_text(owner, repo, inf_wrapper, workers=64):
     # filter out issues with problems
     filtered_issues = []
 
+    if not issues:
+      raise ValueError(f"No issues retrieved for {owner}/{repo}")
     for issue in issues:
         if issue:
             filtered_issues.append(issue)
 
-    logging.info(f'Retrieved {len(filtered_issues)} issues.')
+    logging.info(f'Repo {owner}/{repo} Retrieved {len(filtered_issues)} issues.')
 
     features = []
     labels = []

--- a/py/code_intelligence/gcs_util.py
+++ b/py/code_intelligence/gcs_util.py
@@ -1,5 +1,32 @@
 from google.cloud import storage
 import logging
+import re
+
+GCS_REGEX = re.compile("gs://([^/]*)(/.*)?")
+
+def split_gcs_uri(gcs_uri):
+  """Split a GCS URI into bucket and path."""
+  m = GCS_REGEX.match(gcs_uri)
+  bucket = m.group(1)
+  path = ""
+  if m.group(2):
+    path = m.group(2).lstrip("/")
+  return bucket, path
+
+def check_gcs_object(gcs_path, storage_client=None):
+    """Check if the file exists in the bucket in GCS.
+  
+    Args:      
+      gcs_path: the file name that needs to be checked in GCS, str
+      storage_client: client to bundle configuration needed for API requests
+
+    Return
+    ------
+    bool
+        the file exists in the bucket or not
+    """
+    bucket_name, gcs_file_name = split_gcs_uri(gcs_path)
+    return check_file_in_gcs(bucket_name, gcs_file_name, storage_client=storage_client)
 
 def check_file_in_gcs(bucket_name, gcs_filename, storage_client=None):
     """
@@ -19,6 +46,16 @@ def check_file_in_gcs(bucket_name, gcs_filename, storage_client=None):
     bucket = storage_client.get_bucket(bucket_name)
     return storage.Blob(bucket=bucket, name=gcs_filename).exists(storage_client)
 
+def copy_to_gcs(local_file, gcs_path, storage_client=None):
+    """ Upload a local file to GCS.
+    Args:
+      local_filename: the local file that needs to be uploaded, str      
+      gcs_filename: the file name that is stored in GCS, str      
+      storage_client: client to bundle configuration needed for API requests
+    """
+    bucket_name, gcs_file_name = split_gcs_uri(gcs_path)
+    return upload_file_to_gcs(bucket_name, gcs_file_name, local_file, storage_client=storage_client)
+  
 def upload_file_to_gcs(bucket_name, gcs_filename, local_filename, storage_client=None):
     """
     Upload a local file to GCS.

--- a/py/code_intelligence/util.py
+++ b/py/code_intelligence/util.py
@@ -8,6 +8,7 @@ import json_log_formatter
 
 
 ISSUE_RE = re.compile("([^/]*)/([^#]*)#([0-9]*)")
+ISSUE_URL_RE = re.compile("https://github.com/([^/]*)/([^#]*)/issues/([0-9]*)")
 
 # TODO(jlewi): Might be better to just write it
 # as a json list
@@ -28,6 +29,19 @@ def parse_issue_spec(issue):
     owner, repo, number
   """
   m = ISSUE_RE.match(issue)
+  if not m:
+    return None, None, None
+  return m.group(1), m.group(2), int(m.group(3))
+
+# TODO(jlewi): Unittest
+def parse_issue_url(issue):
+  """Parse an issue in the form https://github.com/{owner}/{repo}/issues/{number}
+  Args:
+    isue: An issue in the form {owner}/{repo}#{number}
+  Returns:
+    owner, repo, number
+  """
+  m = ISSUE_URL_RE.match(issue)
   if not m:
     return None, None, None
   return m.group(1), m.group(2), int(m.group(3))


### PR DESCRIPTION
Compute embeddings for all kubeflow repositories.

* This is the first step in creating an org wide model for all of Kubeflow (#110)

* Modify the Get-GitHub-Issues.ipynb model to reuse code in the embeddings directory.
  * Add some missing packages to requirements.txt.
  * Use the GitHub graphql client to get a list of all repositories.

* Add some missing GCS utilities

* Remove some of the duplication between Get-GitHub-Issues.ipynb and our
  library methods (#122)

* Start fetching the data from bigquery.

  * Using BigQuery turned out to be a lot better for bulk pulling all
    of the Kubeflow issues.

* Use hdf5 to save the data.

* Start a doc to keep track of notes for how to train a Kubeflow model. Add logic to save to hDF5 and do 
a sanity check compared to the inference code

* Add a function to fetch the data using the GitHub API
  * related to https://github.com/kubeflow/code-intelligence/issues/126 swiching the embeddings service t
o use the GraphQL API rather than html fetching
  * I added this function as a way to sanity check that we get the same data
    using bigquery as at inference time.
